### PR TITLE
implementation for  `externalReferences`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * Support for ExternalReferences in BOM and Component (via [#17])
+
+[#17]: https://github.com/CycloneDX/cyclonedx-php-library/pull/17
+
 ## 1.0.3 - 2021-11-15
 
 * Fixed

--- a/src/Core/Enums/ExternalReferenceType.php
+++ b/src/Core/Enums/ExternalReferenceType.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Enums;
+
+/**
+ * See {@link https://cyclonedx.org/schema/bom/1.1 Schema 1.1} for `externalReferenceType`.
+ * See {@link https://cyclonedx.org/schema/bom/1.2 Schema 1.2} for `externalReferenceType`.
+ * See {@link https://cyclonedx.org/schema/bom/1.3 Schema 1.3} for `externalReferenceType`.
+ *
+ * @author jkowalleck
+ */
+abstract class ExternalReferenceType
+{
+    /** Version Control System */
+    public const VCS = 'vcs';
+    /** Issue or defect tracking system, or an Application Lifecycle Management (ALM) system */
+    public const ISSUE_TRACKER = 'issue-tracker';
+    /** Website */
+    public const WEBSITE = 'website';
+    /** Security advisories */
+    public const ADVISORIES = 'advisories';
+    /** Bill-of-material document (CycloneDX, SPDX, SWID, etc) */
+    public const BOM = 'bom';
+    /** Mailing list or discussion group */
+    public const MAILING_LIST = 'mailing-list';
+    /** Social media account */
+    public const SOCIAL = 'social';
+    /** Real-time chat platform */
+    public const CHAT = 'chat';
+    /** Documentation, guides, or how-to instructions */
+    public const DOCUMENTATION = 'documentation';
+    /** Community or commercial support */
+    public const SUPPORT = 'support';
+    /*** Direct or repository download location.*/
+    public const DISTRIBUTION = 'distribution';
+    /** The URL to the license file. If a license URL has been defined in the licensenode, it should also be defined as an external reference for completeness. */
+    public const LICENSE = 'license';
+    /** Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc). */
+    public const BUILD_META = 'build-meta';
+    /** URL to an automated build system. */
+    public const BUILD_SYSTEM = 'build-system';
+    /** Use this if no other types accurately describe the purpose of the external reference. */
+    public const OTHER = 'other';
+
+    /**
+     * @psalm-assert-if-true self::* $value
+     */
+    public static function isValidValue(string $value): bool
+    {
+        $values = (new \ReflectionClass(self::class))->getConstants();
+
+        return \in_array($value, $values, true);
+    }
+}

--- a/src/Core/Models/Bom.php
+++ b/src/Core/Models/Bom.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Models;
 
 use CycloneDX\Core\Repositories\ComponentRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use DomainException;
 
 /**
@@ -55,6 +56,14 @@ class Bom
      * @TODO deprecated rename it in v4 to `$metadata` and also rename the getter/setter
      */
     private $metaData;
+
+    /**
+     * Provides the ability to document external references related to the BOM or
+     * to the project the BOM describes.
+     *
+     * @var ExternalReferenceRepository|null
+     */
+    private $externalReferenceRepository;
 
     public function __construct(?ComponentRepository $componentRepository = null)
     {
@@ -121,6 +130,21 @@ class Bom
     public function setMetaData(?MetaData $metaData): self
     {
         $this->metaData = $metaData;
+
+        return $this;
+    }
+
+    public function getExternalReferenceRepository(): ?ExternalReferenceRepository
+    {
+        return $this->externalReferenceRepository;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setExternalReferenceRepository(?ExternalReferenceRepository $externalReferenceRepository): self
+    {
+        $this->externalReferenceRepository = $externalReferenceRepository;
 
         return $this;
     }

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Enums\Classification;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Repositories\BomRefRepository;
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Repositories\HashRepository;
 use DomainException;
 use PackageUrl\PackageUrl;
@@ -136,6 +137,14 @@ class Component
      * @psalm-suppress PropertyNotSetInConstructor
      */
     private $version;
+
+    /**
+     * Provides the ability to document external references related to the
+     * component or to the project the component describes.
+     *
+     * @var ExternalReferenceRepository|null
+     */
+    private $externalReferenceRepository;
 
     public function getBomRef(): BomRef
     {
@@ -327,6 +336,21 @@ class Component
     public function setDependenciesBomRefRepository(?BomRefRepository $dependenciesBomRefRepository): self
     {
         $this->dependenciesBomRefRepository = $dependenciesBomRefRepository;
+
+        return $this;
+    }
+
+    public function getExternalReferenceRepository(): ?ExternalReferenceRepository
+    {
+        return $this->externalReferenceRepository;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setExternalReferenceRepository(?ExternalReferenceRepository $externalReferenceRepository): self
+    {
+        $this->externalReferenceRepository = $externalReferenceRepository;
 
         return $this;
     }

--- a/src/Core/Models/ExternalReference.php
+++ b/src/Core/Models/ExternalReference.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Models;
+
+use CycloneDX\Core\Enums\ExternalReferenceType;
+use CycloneDX\Core\Repositories\HashRepository;
+use DomainException;
+
+/**
+ * External references provide a way to document systems, sites, and information that may be relevant
+ * but which are not included with the BOM.
+ *
+ * @author jkowalleck
+ */
+class ExternalReference
+{
+    /**
+     * Specifies the type of external reference. There are built-in types to describe common
+     * references. If a type does not exist for the reference being referred to, use the "other" type.
+     *
+     * @var string
+     * @psalm-var ExternalReferenceType::*
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    private $type;
+
+    /**
+     * The URL to the external reference.
+     *
+     * @var string
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    private $url;
+
+    /**
+     * An optional comment describing the external reference.
+     *
+     * @var string|null
+     */
+    private $comment;
+
+    /**
+     * @var HashRepository|null
+     */
+    private $hashes;
+
+    /**
+     * @psalm-return  ExternalReferenceType::*
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type A valid {@see \CycloneDX\Core\Enums\ExternalReferenceType}
+     * @psalm-assert ExternalReferenceType::* $type
+     *
+     * @throws DomainException if value is unknown
+     *
+     * @return $this
+     */
+    public function setType(string $type): self
+    {
+        if (false === ExternalReferenceType::isValidValue($type)) {
+            throw new DomainException("Invalid type: $type");
+        }
+        /** @psalm-var ExternalReferenceType::* $type */
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setUrl(string $url): self
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setComment(?string $comment): self
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+
+    public function getHashes(): ?HashRepository
+    {
+        return $this->hashes;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHashes(?HashRepository $hashes): self
+    {
+        $this->hashes = $hashes;
+
+        return $this;
+    }
+
+    /**
+     * @psalm-assert ExternalReferenceType::* $type
+     *
+     * @throws DomainException if type is unknown
+     */
+    public function __construct(string $type, string $url)
+    {
+        $this->setType($type);
+        $this->setUrl($url);
+    }
+}

--- a/src/Core/Models/ExternalReference.php
+++ b/src/Core/Models/ExternalReference.php
@@ -63,7 +63,7 @@ class ExternalReference
     /**
      * @var HashRepository|null
      */
-    private $hashes;
+    private $hashRepository;
 
     /**
      * @psalm-return  ExternalReferenceType::*
@@ -122,17 +122,17 @@ class ExternalReference
         return $this;
     }
 
-    public function getHashes(): ?HashRepository
+    public function getHashRepository(): ?HashRepository
     {
-        return $this->hashes;
+        return $this->hashRepository;
     }
 
     /**
      * @return $this
      */
-    public function setHashes(?HashRepository $hashes): self
+    public function setHashRepository(?HashRepository $hashRepository): self
     {
-        $this->hashes = $hashes;
+        $this->hashRepository = $hashRepository;
 
         return $this;
     }

--- a/src/Core/Repositories/ExternalReferenceRepository.php
+++ b/src/Core/Repositories/ExternalReferenceRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Repositories;
+
+use CycloneDX\Core\Models\ExternalReference;
+
+/**
+ * @author jkowalleck
+ */
+class ExternalReferenceRepository implements \Countable
+{
+    /**
+     * @var ExternalReference[]
+     * @psalm-var list<ExternalReference>
+     */
+    private $externalReferences = [];
+
+    public function __construct(ExternalReference ...$externalReferences)
+    {
+        $this->addExternalReference(...$externalReferences);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addExternalReference(ExternalReference ...$externalReferences): self
+    {
+        foreach ($externalReferences as $externalReference) {
+            if (\in_array($externalReference, $this->externalReferences, true)) {
+                continue;
+            }
+            $this->externalReferences[] = $externalReference;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return ExternalReference[]
+     * @psalm-return list<ExternalReference>
+     */
+    public function getExternalReferences(): array
+    {
+        return $this->externalReferences;
+    }
+
+    public function count(): int
+    {
+        return \count($this->externalReferences);
+    }
+}

--- a/src/Core/Serialize/DOM/NormalizerFactory.php
+++ b/src/Core/Serialize/DOM/NormalizerFactory.php
@@ -137,4 +137,14 @@ class NormalizerFactory
     {
         return new Normalizers\DependenciesNormalizer($this);
     }
+
+    public function makeForExternalReference(): Normalizers\ExternalReferenceNormalizer
+    {
+        return new Normalizers\ExternalReferenceNormalizer($this);
+    }
+
+    public function makeForExternalReferenceRepository(): Normalizers\ExternalReferenceRepositoryNormalizer
+    {
+        return new Normalizers\ExternalReferenceRepositoryNormalizer($this);
+    }
 }

--- a/src/Core/Serialize/DOM/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/BomNormalizer.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Helpers\SimpleDomTrait;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\MetaData;
 use CycloneDX\Core\Repositories\ComponentRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
 use DOMElement;
 
@@ -61,8 +62,8 @@ class BomNormalizer extends AbstractNormalizer
             [
                 $this->normalizeMetaData($bom->getMetaData()),
                 $this->normalizeComponents($bom->getComponentRepository()),
+                $this->normalizeExternalReferences($bom->getExternalReferenceRepository()),
                 $this->normalizeDependencies($bom),
-                // externalReferences
             ]
         );
 
@@ -109,6 +110,18 @@ class BomNormalizer extends AbstractNormalizer
             : $this->simpleDomAppendChildren(
                 $factory->getDocument()->createElement('dependencies'),
                 $deps
+            );
+    }
+
+    private function normalizeExternalReferences(?ExternalReferenceRepository $externalReferenceRepository): ?DOMElement
+    {
+        $factory = $this->getNormalizerFactory();
+
+        return null === $externalReferenceRepository || 0 === \count($externalReferenceRepository)
+            ? null
+            : $this->simpleDomAppendChildren(
+                $factory->getDocument()->createElement('externalReferences'),
+                $factory->makeForExternalReferenceRepository()->normalize($externalReferenceRepository)
             );
     }
 }

--- a/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Helpers\SimpleDomTrait;
 use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Repositories\HashRepository;
 use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
 use DomainException;
@@ -87,7 +88,7 @@ class ComponentNormalizer extends AbstractNormalizer
                 $this->normalizePurl($component->getPackageUrl()),
                 // modified
                 // pedigree
-                // externalReferences
+                $this->normalizeExternalReferences($component->getExternalReferenceRepository()),
                 // components
             ]
         );
@@ -161,5 +162,17 @@ class ComponentNormalizer extends AbstractNormalizer
         return null === $purl
             ? null
             : $this->simpleDomSafeTextElement($this->getNormalizerFactory()->getDocument(), 'purl', (string) $purl);
+    }
+
+    private function normalizeExternalReferences(?ExternalReferenceRepository $externalReferenceRepository): ?DOMElement
+    {
+        $factory = $this->getNormalizerFactory();
+
+        return null === $externalReferenceRepository || 0 === \count($externalReferenceRepository)
+            ? null
+            : $this->simpleDomAppendChildren(
+                $factory->getDocument()->createElement('externalReferences'),
+                $factory->makeForExternalReferenceRepository()->normalize($externalReferenceRepository)
+            );
     }
 }

--- a/src/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Helpers\SimpleDomTrait;
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
+use DOMElement;
+
+/**
+ * @author jkowalleck
+ */
+class ExternalReferenceNormalizer extends AbstractNormalizer
+{
+    use SimpleDomTrait;
+
+    /**
+     * @throws \DomainException
+     */
+    public function normalize(ExternalReference $externalReference): DOMElement
+    {
+        // would throw DomainException if the type was not supported
+
+        $doc = $this->getNormalizerFactory()->getDocument();
+
+        return $this->simpleDomAppendChildren(
+            $this->simpleDomSetAttributes(
+                $doc->createElement('reference'),
+                [
+                    'type' => $externalReference->getType(),
+                ]
+            ),
+            [
+                $this->simpleDomSafeTextElement($doc, 'url', $externalReference->getUrl()),
+                $this->simpleDomSafeTextElement($doc, 'comment', $externalReference->getComment()),
+                $this->normalizeHashes($externalReference->getHashRepository()),
+            ]
+        );
+    }
+
+    private function normalizeHashes(?HashRepository $hashes): ?DOMElement
+    {
+        $factory = $this->getNormalizerFactory();
+
+        return null === $hashes || 0 === \count($hashes)
+            ? null
+            : $this->simpleDomAppendChildren(
+                $factory->getDocument()->createElement('hashes'),
+                $factory->makeForHashRepository()->normalize($hashes)
+            );
+    }
+}

--- a/src/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizer.php
@@ -41,7 +41,7 @@ class ExternalReferenceNormalizer extends AbstractNormalizer
      */
     public function normalize(ExternalReference $externalReference): DOMElement
     {
-        // would throw DomainException if the type was not supported
+        // could throw DomainException if the type was not supported
 
         $doc = $this->getNormalizerFactory()->getDocument();
 
@@ -63,6 +63,10 @@ class ExternalReferenceNormalizer extends AbstractNormalizer
     private function normalizeHashes(?HashRepository $hashes): ?DOMElement
     {
         $factory = $this->getNormalizerFactory();
+
+        if (false === $factory->getSpec()->supportsExternalReferenceHashes()) {
+            return null;
+        }
 
         return null === $hashes || 0 === \count($hashes)
             ? null

--- a/src/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
+use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
+use DOMElement;
+
+/**
+ * @author jkowalleck
+ */
+class ExternalReferenceRepositoryNormalizer extends AbstractNormalizer
+{
+    /**
+     * @return DOMElement[]
+     * @psalm-return list<DOMElement>
+     */
+    public function normalize(ExternalReferenceRepository $repo): array
+    {
+        $normalizer = $this->getNormalizerFactory()->makeForExternalReference();
+
+        $externalReferences = [];
+        foreach ($repo->getExternalReferences() as $externalReference) {
+            try {
+                $externalReferences[] = $normalizer->normalize($externalReference);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+        }
+
+        return $externalReferences;
+    }
+}

--- a/src/Core/Serialize/JSON/NormalizerFactory.php
+++ b/src/Core/Serialize/JSON/NormalizerFactory.php
@@ -127,4 +127,14 @@ class NormalizerFactory
     {
         return new Normalizers\DependenciesNormalizer($this);
     }
+
+    public function makeForExternalReference(): Normalizers\ExternalReferenceNormalizer
+    {
+        return new Normalizers\ExternalReferenceNormalizer($this);
+    }
+
+    public function makeForExternalReferenceRepository(): Normalizers\ExternalReferenceRepositoryNormalizer
+    {
+        return new Normalizers\ExternalReferenceRepositoryNormalizer($this);
+    }
 }

--- a/src/Core/Serialize/JSON/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/BomNormalizer.php
@@ -26,6 +26,7 @@ namespace CycloneDX\Core\Serialize\JSON\Normalizers;
 use CycloneDX\Core\Helpers\NullAssertionTrait;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\MetaData;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
 
 /**
@@ -48,6 +49,7 @@ class BomNormalizer extends AbstractNormalizer
                 'version' => $bom->getVersion(),
                 'metadata' => $this->normalizeMetaData($bom->getMetaData()),
                 'components' => $factory->makeForComponentRepository()->normalize($bom->getComponentRepository()),
+                'externalReferences' => $this->normalizeExternalReferences($bom->getExternalReferenceRepository()),
                 'dependencies' => $this->normalizeDependencies($bom),
             ],
             [$this, 'isNotNull']
@@ -71,6 +73,13 @@ class BomNormalizer extends AbstractNormalizer
         return empty($data)
             ? null
             : $data;
+    }
+
+    private function normalizeExternalReferences(?ExternalReferenceRepository $externalReferenceRepository): ?array
+    {
+        return null === $externalReferenceRepository || 0 === \count($externalReferenceRepository)
+            ? null
+            : $this->getNormalizerFactory()->makeForExternalReferenceRepository()->normalize($externalReferenceRepository);
     }
 
     private function normalizeDependencies(Bom $bom): ?array

--- a/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Helpers\NullAssertionTrait;
 use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Repositories\HashRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
 use DomainException;
@@ -72,6 +73,7 @@ class ComponentNormalizer extends AbstractNormalizer
                 'licenses' => $this->normalizeLicense($component->getLicense()),
                 'hashes' => $this->normalizeHashes($component->getHashRepository()),
                 'purl' => $this->normalizePurl($component->getPackageUrl()),
+                'externalReferences' => $this->normalizeExternalReferences($component->getExternalReferenceRepository()),
             ],
             [$this, 'isNotNull']
         );
@@ -125,5 +127,12 @@ class ComponentNormalizer extends AbstractNormalizer
         return null === $purl
             ? null
             : (string) $purl;
+    }
+
+    private function normalizeExternalReferences(?ExternalReferenceRepository $externalReferenceRepository): ?array
+    {
+        return null === $externalReferenceRepository || 0 === \count($externalReferenceRepository)
+            ? null
+            : $this->getNormalizerFactory()->makeForExternalReferenceRepository()->normalize($externalReferenceRepository);
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Helpers\NullAssertionTrait;
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+
+/**
+ * @author jkowalleck
+ */
+class ExternalReferenceNormalizer extends AbstractNormalizer
+{
+    use NullAssertionTrait;
+
+    /**
+     * @throws \DomainException
+     */
+    public function normalize(ExternalReference $externalReference): array
+    {
+        // would throw DomainException if the type was not supported
+
+        return array_filter(
+            [
+                'type' => $externalReference->getType(),
+                'url' => $externalReference->getUrl(),
+                'comment' => $externalReference->getComment(),
+                'hashes' => $this->normalizeHashes($externalReference->getHashRepository()),
+            ],
+            [$this, 'isNotNull']
+        );
+    }
+
+    private function normalizeHashes(?HashRepository $hashes): ?array
+    {
+        return null === $hashes || 0 === \count($hashes)
+            ? null
+            : $this->getNormalizerFactory()->makeForHashRepository()->normalize($hashes);
+    }
+}

--- a/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
@@ -40,7 +40,7 @@ class ExternalReferenceNormalizer extends AbstractNormalizer
      */
     public function normalize(ExternalReference $externalReference): array
     {
-        // would throw DomainException if the type was not supported
+        // could throw DomainException if the type was not supported
 
         return array_filter(
             [
@@ -55,8 +55,14 @@ class ExternalReferenceNormalizer extends AbstractNormalizer
 
     private function normalizeHashes(?HashRepository $hashes): ?array
     {
+        $factory = $this->getNormalizerFactory();
+
+        if (false === $factory->getSpec()->supportsExternalReferenceHashes()) {
+            return null;
+        }
+
         return null === $hashes || 0 === \count($hashes)
             ? null
-            : $this->getNormalizerFactory()->makeForHashRepository()->normalize($hashes);
+            : $factory->makeForHashRepository()->normalize($hashes);
     }
 }

--- a/src/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
+use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+
+/**
+ * @author jkowalleck
+ */
+class ExternalReferenceRepositoryNormalizer extends AbstractNormalizer
+{
+    /**
+     * @return array[]
+     * @psalm-return list<array>
+     */
+    public function normalize(ExternalReferenceRepository $repo): array
+    {
+        $normalizer = $this->getNormalizerFactory()->makeForExternalReference();
+
+        $externalReferences = [];
+        foreach ($repo->getExternalReferences() as $externalReference) {
+            try {
+                $item = $normalizer->normalize($externalReference);
+            } catch (\DomainException $exception) {
+                continue;
+            }
+            if (false === empty($item)) {
+                $externalReferences[] = $item;
+            }
+        }
+
+        return $externalReferences;
+    }
+}

--- a/src/Core/Spec/Spec11.php
+++ b/src/Core/Spec/Spec11.php
@@ -79,4 +79,9 @@ final class Spec11 implements SpecInterface
     {
         return false;
     }
+
+    public function supportsExternalReferenceHashes(): bool
+    {
+        return false;
+    }
 }

--- a/src/Core/Spec/Spec12.php
+++ b/src/Core/Spec/Spec12.php
@@ -87,4 +87,9 @@ final class Spec12 implements SpecInterface
     {
         return true;
     }
+
+    public function supportsExternalReferenceHashes(): bool
+    {
+        return false;
+    }
 }

--- a/src/Core/Spec/Spec13.php
+++ b/src/Core/Spec/Spec13.php
@@ -87,4 +87,9 @@ final class Spec13 implements SpecInterface
     {
         return true;
     }
+
+    public function supportsExternalReferenceHashes(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -82,4 +82,9 @@ interface SpecInterface
      * version < 1.2 does not support BomRef.
      */
     public function supportsDependencies(): bool;
+
+    /**
+     * version < 1.3 does not support hashes in ExternalReference.
+     */
+    public function supportsExternalReferenceHashes(): bool;
 }

--- a/tests/Core/Enums/ExternalReferenceTypeTest.php
+++ b/tests/Core/Enums/ExternalReferenceTypeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Enums;
+
+use CycloneDX\Core\Enums\ExternalReferenceType;
+use CycloneDX\Tests\_data\BomSpecData;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Enums\ExternalReferenceType
+ */
+class ExternalReferenceTypeTest extends TestCase
+{
+    /**
+     * @dataProvider dpKnownValues
+     * @dataProvider dpUnknownValue
+     */
+    public function testIsValidValue(string $value, bool $expected): void
+    {
+        self::assertSame($expected, ExternalReferenceType::isValidValue($value));
+    }
+
+    public function dpKnownValues(): \Generator
+    {
+        $allValues = (new \ReflectionClass(ExternalReferenceType::class))->getConstants();
+        foreach ($allValues as $value) {
+            yield $value => [$value, true];
+        }
+    }
+
+    public function dpUnknownValue(): \Generator
+    {
+        yield 'invalid' => ['UnknownExternalReferenceType', false];
+    }
+
+    /**
+     * @dataProvider dpSchemaValues
+     */
+    public function testIsValidKnowsAllSchemaValues(string $value): void
+    {
+        self::assertTrue(ExternalReferenceType::isValidValue($value));
+    }
+
+    public function dpSchemaValues(): \Generator
+    {
+        $allValues = array_unique(array_merge(
+            BomSpecData::getExternalReferenceTypeForVersion('1.1'),
+            BomSpecData::getExternalReferenceTypeForVersion('1.2'),
+            BomSpecData::getExternalReferenceTypeForVersion('1.3'),
+        ));
+        foreach ($allValues as $value) {
+            yield $value => [$value];
+        }
+    }
+}

--- a/tests/Core/Models/BomTest.php
+++ b/tests/Core/Models/BomTest.php
@@ -26,6 +26,7 @@ namespace CycloneDX\Tests\Core\Models;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\MetaData;
 use CycloneDX\Core\Repositories\ComponentRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,8 +41,6 @@ class BomTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->bom = new Bom($this->createStub(ComponentRepository::class));
     }
 
@@ -50,7 +49,8 @@ class BomTest extends TestCase
     public function testComponentsSetterGetter(): void
     {
         $components = $this->createStub(ComponentRepository::class);
-        $this->bom->setComponentRepository($components);
+        $bom = $this->bom->setComponentRepository($components);
+        self::assertSame($this->bom, $bom);
         self::assertSame($components, $this->bom->getComponentRepository());
     }
 
@@ -61,7 +61,8 @@ class BomTest extends TestCase
     public function testVersionSetterGetter(): void
     {
         $version = random_int(1, 255);
-        $this->bom->setVersion($version);
+        $bom = $this->bom->setVersion($version);
+        self::assertSame($this->bom, $bom);
         self::assertSame($version, $this->bom->getVersion());
     }
 
@@ -79,9 +80,22 @@ class BomTest extends TestCase
     public function testMetaDataSetterGetter(): void
     {
         $metaData = $this->createStub(MetaData::class);
-        $this->bom->setMetaData($metaData);
+        $bom = $this->bom->setMetaData($metaData);
+        self::assertSame($this->bom, $bom);
         self::assertSame($metaData, $this->bom->getMetaData());
     }
 
     // endregion metaData setter&getter
+
+    // region externalReferenceRepository setter&getter
+
+    public function testExternalReferenceRepositorySetterGetter(): void
+    {
+        $extRefRepo = $this->createStub(ExternalReferenceRepository::class);
+        $bom = $this->bom->setExternalReferenceRepository($extRefRepo);
+        self::assertSame($this->bom, $bom);
+        self::assertSame($extRefRepo, $this->bom->getExternalReferenceRepository());
+    }
+
+    // endregion externalReferenceRepository setter&getter
 }

--- a/tests/Core/Models/ComponentTest.php
+++ b/tests/Core/Models/ComponentTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Repositories\BomRefRepository;
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Repositories\HashRepository;
 use PackageUrl\PackageUrl;
 use PHPUnit\Framework\TestCase;
@@ -243,6 +244,18 @@ class ComponentTest extends TestCase
     }
 
     // endregion dependenciesBomRefRepository setter&getter
+
+    // region externalReferenceRepository setter&getter
+
+    public function testExternalReferenceRepositorySetterGetter(): void
+    {
+        $extRefRepo = $this->createStub(ExternalReferenceRepository::class);
+        $bom = $this->component->setExternalReferenceRepository($extRefRepo);
+        self::assertSame($this->component, $bom);
+        self::assertSame($extRefRepo, $this->component->getExternalReferenceRepository());
+    }
+
+    // endregion externalReferenceRepository setter&getter
 
     // region clone
 

--- a/tests/Core/Models/ExternalReferenceTest.php
+++ b/tests/Core/Models/ExternalReferenceTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Models;
+
+use CycloneDX\Core\Enums\ExternalReferenceType;
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\HashRepository;
+use DomainException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Models\ExternalReference
+ *
+ * @uses \CycloneDX\Core\Enums\ExternalReferenceType::isValidValue()
+ */
+class ExternalReferenceTest extends TestCase
+{
+    public function testConstructor(): ExternalReference
+    {
+        $extRef = new ExternalReference(ExternalReferenceType::OTHER, 'https://localhost/dummy');
+
+        $this->assertSame(ExternalReferenceType::OTHER, $extRef->getType());
+        $this->assertSame('https://localhost/dummy', $extRef->getUrl());
+        $this->assertNull($extRef->getComment());
+        $this->assertNull($extRef->getHashes());
+
+        return $extRef;
+    }
+
+    // region test Type
+
+    /**
+     * @depends testConstructor
+     */
+    public function testTypeSetterAndGetter(ExternalReference $extRef): void
+    {
+        $got = $extRef->setType(ExternalReferenceType::CHAT);
+        $this->assertSame($extRef, $got);
+        $this->assertSame(ExternalReferenceType::CHAT, $extRef->getType());
+    }
+
+    public function testConstructorWithInvalidType(): void
+    {
+        $this->expectException(DomainException::class);
+        new ExternalReference('something else', 'https://localhost/dummy');
+    }
+
+    /**
+     * @depends testConstructor
+     */
+    public function testTypeSetterWithInvalidType(ExternalReference $extRef): void
+    {
+        $this->expectException(DomainException::class);
+        $extRef->setType('something else');
+    }
+
+    // endregion test Type
+
+    // region test Url
+
+    /**
+     * @depends testConstructor
+     */
+    public function testUrlSetterAndGetter(ExternalReference $extRef): void
+    {
+        $got = $extRef->setUrl('ftp://localhost/foobar');
+        $this->assertSame($extRef, $got);
+        $this->assertSame('ftp://localhost/foobar', $extRef->getUrl());
+    }
+
+    /**
+     * @depends testConstructor
+     */
+    public function testUrlSetterWithURN(ExternalReference $extRef): void
+    {
+        $got = $extRef->setUrl('urn:uuid:bdd819e6-ee8f-42d7-a4d0-166ff44d51e8');
+        $this->assertSame($extRef, $got);
+        $this->assertSame('urn:uuid:bdd819e6-ee8f-42d7-a4d0-166ff44d51e8', $extRef->getUrl());
+    }
+
+    // endregion test Url
+
+    // region test Comment
+
+    /**
+     * @depends testConstructor
+     */
+    public function testCommentSetterAndGetter(ExternalReference $extRef): void
+    {
+        $got = $extRef->setComment('foobar');
+        $this->assertSame($extRef, $got);
+        $this->assertSame('foobar', $extRef->getComment());
+    }
+
+    // endregion test Comment
+
+    // region test Comment
+
+    /**
+     * @depends testConstructor
+     */
+    public function testHashesSetterAndGetter(ExternalReference $extRef): void
+    {
+        $hashes = $this->createStub(HashRepository::class);
+        $got = $extRef->setHashes($hashes);
+        $this->assertSame($extRef, $got);
+        $this->assertSame($hashes, $extRef->getHashes());
+    }
+
+    // endregion test Comment
+}

--- a/tests/Core/Models/ExternalReferenceTest.php
+++ b/tests/Core/Models/ExternalReferenceTest.php
@@ -43,7 +43,7 @@ class ExternalReferenceTest extends TestCase
         $this->assertSame(ExternalReferenceType::OTHER, $extRef->getType());
         $this->assertSame('https://localhost/dummy', $extRef->getUrl());
         $this->assertNull($extRef->getComment());
-        $this->assertNull($extRef->getHashes());
+        $this->assertNull($extRef->getHashRepository());
 
         return $extRef;
     }
@@ -123,9 +123,9 @@ class ExternalReferenceTest extends TestCase
     public function testHashesSetterAndGetter(ExternalReference $extRef): void
     {
         $hashes = $this->createStub(HashRepository::class);
-        $got = $extRef->setHashes($hashes);
+        $got = $extRef->setHashRepository($hashes);
         $this->assertSame($extRef, $got);
-        $this->assertSame($hashes, $extRef->getHashes());
+        $this->assertSame($hashes, $extRef->getHashRepository());
     }
 
     // endregion test Comment

--- a/tests/Core/Repositories/ExternalReferenceRepositoryTest.php
+++ b/tests/Core/Repositories/ExternalReferenceRepositoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Repositories;
+
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CycloneDX\Core\Repositories\ExternalReferenceRepository
+ */
+class ExternalReferenceRepositoryTest extends TestCase
+{
+    public function testEmptyConstructor(): void
+    {
+        $repo = new ExternalReferenceRepository();
+
+        self::assertCount(0, $repo);
+        self::assertSame([], $repo->getExternalReferences());
+    }
+
+    public function testConstructAndGet(): void
+    {
+        $externalReference1 = $this->createStub(ExternalReference::class);
+        $externalReference2 = $this->createStub(ExternalReference::class);
+
+        $repo = new ExternalReferenceRepository(
+            $externalReference1,
+            $externalReference2,
+            $externalReference1,
+            $externalReference2
+        );
+
+        self::assertCount(2, $repo);
+        self::assertCount(2, $repo->getExternalReferences());
+        self::assertContains($externalReference1, $repo->getExternalReferences());
+        self::assertContains($externalReference2, $repo->getExternalReferences());
+    }
+
+    public function testAddAndGetExternalReference(): void
+    {
+        $externalReference1 = $this->createStub(ExternalReference::class);
+        $externalReference2 = $this->createStub(ExternalReference::class);
+        $externalReference3 = $this->createStub(ExternalReference::class);
+        $repo = new ExternalReferenceRepository($externalReference1, $externalReference2);
+
+        $actual = $repo->addExternalReference($externalReference2, $externalReference3, $externalReference3);
+
+        self::assertSame($repo, $actual);
+        self::assertCount(3, $repo);
+        self::assertCount(3, $repo->getExternalReferences());
+        self::assertContains($externalReference1, $repo->getExternalReferences());
+        self::assertContains($externalReference2, $repo->getExternalReferences());
+        self::assertContains($externalReference3, $repo->getExternalReferences());
+    }
+}

--- a/tests/Core/Serialize/DOM/NormalizerFactoryTest.php
+++ b/tests/Core/Serialize/DOM/NormalizerFactoryTest.php
@@ -250,4 +250,28 @@ class NormalizerFactoryTest extends TestCase
         self::assertInstanceOf(Normalizers\DependenciesNormalizer::class, $normalizer);
         self::assertSame($factory, $normalizer->getNormalizerFactory());
     }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceNormalizer
+     */
+    public function testMakeForExternalReference(NormalizerFactory $factory): void
+    {
+        $normalizer = $factory->makeForExternalReference();
+        self::assertInstanceOf(Normalizers\ExternalReferenceNormalizer::class, $normalizer);
+        self::assertSame($factory, $normalizer->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceRepositoryNormalizer
+     */
+    public function testMakeForExternalReferenceRepository(NormalizerFactory $factory): void
+    {
+        $normalizer = $factory->makeForExternalReferenceRepository();
+        self::assertInstanceOf(Normalizers\ExternalReferenceRepositoryNormalizer::class, $normalizer);
+        self::assertSame($factory, $normalizer->getNormalizerFactory());
+    }
 }

--- a/tests/Core/Serialize/DOM/Normalizers/BomNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/BomNormalizerTest.php
@@ -277,6 +277,8 @@ class BomNormalizerTest extends TestCase
         );
     }
 
+    // region normalize ExternalReferences
+
     public function testNormalizeExternalReferences(): void
     {
         $spec = $this->createConfiguredMock(
@@ -360,4 +362,6 @@ class BomNormalizerTest extends TestCase
             $actual
         );
     }
+
+    // endregion normalize ExternalReferences
 }

--- a/tests/Core/Serialize/DOM/Normalizers/BomNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/BomNormalizerTest.php
@@ -26,11 +26,9 @@ namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\MetaData;
 use CycloneDX\Core\Repositories\ComponentRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
-use CycloneDX\Core\Serialize\DOM\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\DependenciesNormalizer;
-use CycloneDX\Core\Serialize\DOM\Normalizers\MetaDataNormalizer;
+use CycloneDX\Core\Serialize\DOM\Normalizers;
 use CycloneDX\Core\Spec\SpecInterface;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
 use DOMDocument;
@@ -55,7 +53,7 @@ class BomNormalizerTest extends TestCase
                 'getDocument' => new DOMDocument(),
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -76,7 +74,7 @@ class BomNormalizerTest extends TestCase
     public function testNormalizeComponents(): void
     {
         $spec = $this->createConfiguredMock(SpecInterface::class, ['getVersion' => '1.2']);
-        $componentsNormalizer = $this->createMock(ComponentRepositoryNormalizer::class);
+        $componentsNormalizer = $this->createMock(Normalizers\ComponentRepositoryNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -85,7 +83,7 @@ class BomNormalizerTest extends TestCase
                 'makeForComponentRepository' => $componentsNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -118,7 +116,7 @@ class BomNormalizerTest extends TestCase
                 'supportsMetaData' => true,
             ]
         );
-        $metadataNormalizer = $this->createMock(MetaDataNormalizer::class);
+        $metadataNormalizer = $this->createMock(Normalizers\MetaDataNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -127,7 +125,7 @@ class BomNormalizerTest extends TestCase
                 'makeForMetaData' => $metadataNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -161,7 +159,7 @@ class BomNormalizerTest extends TestCase
                 'supportsMetaData' => false,
             ]
         );
-        $metadataNormalizer = $this->createMock(MetaDataNormalizer::class);
+        $metadataNormalizer = $this->createMock(Normalizers\MetaDataNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -170,7 +168,7 @@ class BomNormalizerTest extends TestCase
                 'makeForMetaData' => $metadataNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -202,7 +200,7 @@ class BomNormalizerTest extends TestCase
                 'supportsDependencies' => true,
             ]
         );
-        $dependencyNormalizer = $this->createMock(DependenciesNormalizer::class);
+        $dependencyNormalizer = $this->createMock(Normalizers\DependenciesNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -211,7 +209,7 @@ class BomNormalizerTest extends TestCase
                 'makeForDependencies' => $dependencyNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -245,7 +243,7 @@ class BomNormalizerTest extends TestCase
                 'supportsDependencies' => true,
             ]
         );
-        $dependencyNormalizer = $this->createMock(DependenciesNormalizer::class);
+        $dependencyNormalizer = $this->createMock(Normalizers\DependenciesNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -254,7 +252,7 @@ class BomNormalizerTest extends TestCase
                 'makeForDependencies' => $dependencyNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -274,6 +272,90 @@ class BomNormalizerTest extends TestCase
             '<bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="23">'.
             '<components></components>'.
             // 'dependencies' is unset,
+            '</bom>',
+            $actual
+        );
+    }
+
+    public function testNormalizeExternalReferences(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.2',
+            ]
+        );
+        $externalReferenceRepositoryNormalizer = $this->createMock(Normalizers\ExternalReferenceRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForExternalReferenceRepository' => $externalReferenceRepositoryNormalizer,
+            ]
+        );
+        $normalizer = new Normalizers\BomNormalizer($factory);
+        $bom = $this->createConfiguredMock(
+            Bom::class,
+            [
+                'getVersion' => 23,
+                'getExternalReferenceRepository' => $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 1]),
+            ]
+        );
+
+        $externalReferenceRepositoryNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($bom->getExternalReferenceRepository())
+            ->willReturn([$factory->getDocument()->createElement('FakeReferenceRepositoryNormalized', 'faked')]);
+
+        $actual = $normalizer->normalize($bom);
+
+        self::assertStringEqualsDomNode(
+            '<bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="23">'.
+            '<components></components>'.
+            '<externalReferences><FakeReferenceRepositoryNormalized>faked</FakeReferenceRepositoryNormalized></externalReferences>'.
+            '</bom>',
+            $actual
+        );
+    }
+
+    public function testNormalizeExternalReferencesOmitIfEmpty(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.2',
+            ]
+        );
+        $externalReferenceRepositoryNormalizer = $this->createMock(Normalizers\ExternalReferenceRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'getDocument' => new DOMDocument(),
+                'makeForExternalReferenceRepository' => $externalReferenceRepositoryNormalizer,
+            ]
+        );
+        $normalizer = new Normalizers\BomNormalizer($factory);
+        $bom = $this->createConfiguredMock(
+            Bom::class,
+            [
+                'getVersion' => 23,
+                'getExternalReferenceRepository' => $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 0]),
+            ]
+        );
+
+        $externalReferenceRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($bom->getExternalReferenceRepository())
+            ->willReturn(['FakeReferenceRepositoryNormalized']);
+
+        $actual = $normalizer->normalize($bom);
+
+        self::assertStringEqualsDomNode(
+            '<bom xmlns="http://cyclonedx.org/schema/bom/1.2" version="23">'.
+            '<components></components>'.
+            // externalReferences are omitted
             '</bom>',
             $actual
         );

--- a/tests/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/ExternalReferenceNormalizerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
+use CycloneDX\Core\Serialize\DOM\Normalizers;
+use CycloneDX\Core\Spec\SpecInterface;
+use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceNormalizer
+ * @covers \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+ */
+class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
+{
+    use DomNodeAssertionTrait;
+
+    /**
+     * @throws \Exception on assertion error
+     */
+    public function testNormalizeTypeAndUrl(): void
+    {
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getDocument' => new \DOMDocument(),
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => null,
+        ]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertStringEqualsDomNode(
+            '<reference type="someType"><url>someUrl</url></reference>',
+            $actual
+        );
+    }
+
+    /**
+     * @throws \Exception on assertion error
+     */
+    public function testNormalizeComment(): void
+    {
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getDocument' => new \DOMDocument(),
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => 'someComment',
+            'getHashRepository' => null,
+        ]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertStringEqualsDomNode(
+            '<reference type="someType"><url>someUrl</url><comment>someComment</comment></reference>',
+            $actual
+        );
+    }
+
+    // region normalize hashes
+
+    /**
+     * @throws \Exception on assertion error
+     */
+    public function testNormalizeHashes(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => true,
+            ]),
+            'getDocument' => new \DOMDocument(),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 1]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($extRef->getHashRepository())
+            ->willReturn([$normalizerFactory->getDocument()->createElement('FakeHash', 'dummy')]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertStringEqualsDomNode(
+            '<reference type="someType">'.
+            '<url>someUrl</url>'.
+            '<hashes><FakeHash>dummy</FakeHash></hashes>'.
+            '</reference>',
+            $actual
+        );
+    }
+
+    /**
+     * @throws \Exception on assertion error
+     */
+    public function testNormalizeHashesOmitIfEmpty(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => true,
+            ]),
+            'getDocument' => new \DOMDocument(),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 0]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($extRef->getHashRepository());
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertStringEqualsDomNode(
+            '<reference type="someType"><url>someUrl</url></reference>',
+            $actual
+        );
+    }
+
+    /**
+     * @throws \Exception on assertion error
+     */
+    public function testNormalizeHashesOmitIfNotSupported(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => false,
+            ]),
+            'getDocument' => new \DOMDocument(),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 1]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($extRef->getHashRepository());
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertStringEqualsDomNode(
+            '<reference type="someType"><url>someUrl</url></reference>',
+            $actual
+        );
+    }
+
+    // endregion normalize hashes
+}

--- a/tests/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\DOM\Normalizers;
+
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
+use CycloneDX\Core\Serialize\DOM\NormalizerFactory;
+use CycloneDX\Core\Serialize\DOM\Normalizers;
+use CycloneDX\Core\Spec\SpecInterface;
+use DOMElement;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceRepositoryNormalizer
+ * @covers \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+ *
+ * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceNormalizer
+ */
+class ExternalReferenceRepositoryNormalizerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @uses \CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer
+     */
+    public function testNormalizeEmpty(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $repo = $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 0]);
+
+        $actual = $normalizer->normalize($repo);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalize(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $externalReference = $this->createStub(ExternalReference::class);
+        $repo = $this->createConfiguredMock(ExternalReferenceRepository::class, [
+            'count' => 1,
+            'getExternalReferences' => [$externalReference],
+        ]);
+        $FakeExtRef = $this->createStub(DOMElement::class);
+
+        $externalReferenceNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($externalReference)
+            ->willReturn($FakeExtRef);
+
+        $actual = $normalizer->normalize($repo);
+
+        self::assertSame([$FakeExtRef], $actual);
+    }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $extRef1 = $this->createStub(ExternalReference::class);
+        $extRef2 = $this->createStub(ExternalReference::class);
+        $tools = $this->createConfiguredMock(ExternalReferenceRepository::class, [
+            'count' => 1,
+            'getExternalReferences' => [$extRef1, $extRef2],
+        ]);
+
+        $externalReferenceNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$extRef1], [$extRef2])
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+}

--- a/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
+++ b/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
@@ -241,7 +241,7 @@ class NormalizerFactoryTest extends TestCase
     /**
      * @depends testConstructor
      *
-     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ToolNormalizer
+     * @uses    \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
      * @uses    \CycloneDX\Core\Serialize\JSON\Normalizers\DependenciesNormalizer
      */
     public function testMakeForDependencies(NormalizerFactory $factory): void
@@ -254,7 +254,7 @@ class NormalizerFactoryTest extends TestCase
     /**
      * @depends testConstructor
      *
-     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceNormalizer
+     * @uses    \CycloneDX\Core\Serialize\JSON\Normalizers\ExternalReferenceNormalizer
      */
     public function testMakeForExternalReference(NormalizerFactory $factory): void
     {
@@ -266,7 +266,7 @@ class NormalizerFactoryTest extends TestCase
     /**
      * @depends testConstructor
      *
-     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceRepositoryNormalizer
+     * @uses    \CycloneDX\Core\Serialize\JSON\Normalizers\ExternalReferenceRepositoryNormalizer
      */
     public function testMakeForExternalReferenceRepository(NormalizerFactory $factory): void
     {

--- a/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
+++ b/tests/Core/Serialize/JSON/NormalizerFactoryTest.php
@@ -250,4 +250,28 @@ class NormalizerFactoryTest extends TestCase
         self::assertInstanceOf(Normalizers\DependenciesNormalizer::class, $normalizer);
         self::assertSame($factory, $normalizer->getNormalizerFactory());
     }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceNormalizer
+     */
+    public function testMakeForExternalReference(NormalizerFactory $factory): void
+    {
+        $normalizer = $factory->makeForExternalReference();
+        self::assertInstanceOf(Normalizers\ExternalReferenceNormalizer::class, $normalizer);
+        self::assertSame($factory, $normalizer->getNormalizerFactory());
+    }
+
+    /**
+     * @depends testConstructor
+     *
+     * @uses    \CycloneDX\Core\Serialize\DOM\Normalizers\ExternalReferenceRepositoryNormalizer
+     */
+    public function testMakeForExternalReferenceRepository(NormalizerFactory $factory): void
+    {
+        $normalizer = $factory->makeForExternalReferenceRepository();
+        self::assertInstanceOf(Normalizers\ExternalReferenceRepositoryNormalizer::class, $normalizer);
+        self::assertSame($factory, $normalizer->getNormalizerFactory());
+    }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/BomNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/BomNormalizerTest.php
@@ -26,11 +26,9 @@ namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\MetaData;
 use CycloneDX\Core\Repositories\ComponentRepository;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
-use CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\DependenciesNormalizer;
-use CycloneDX\Core\Serialize\JSON\Normalizers\MetaDataNormalizer;
+use CycloneDX\Core\Serialize\JSON\Normalizers;
 use CycloneDX\Core\Spec\SpecInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -52,7 +50,7 @@ class BomNormalizerTest extends TestCase
                 'getSpec' => $spec,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -60,7 +58,7 @@ class BomNormalizerTest extends TestCase
             ]
         );
 
-        $got = $normalizer->normalize($bom);
+        $actual = $normalizer->normalize($bom);
 
         self::assertSame(
             [
@@ -69,14 +67,14 @@ class BomNormalizerTest extends TestCase
                 'version' => 23,
                 'components' => [],
             ],
-            $got
+            $actual
         );
     }
 
     public function testNormalizeComponents(): void
     {
         $spec = $this->createConfiguredMock(SpecInterface::class, ['getVersion' => '1.2']);
-        $componentsNormalizer = $this->createMock(ComponentRepositoryNormalizer::class);
+        $componentsNormalizer = $this->createMock(Normalizers\ComponentRepositoryNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -84,7 +82,7 @@ class BomNormalizerTest extends TestCase
                 'makeForComponentRepository' => $componentsNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -98,7 +96,7 @@ class BomNormalizerTest extends TestCase
             ->with($bom->getComponentRepository())
             ->willReturn(['FakeComponents']);
 
-        $got = $normalizer->normalize($bom);
+        $actual = $normalizer->normalize($bom);
 
         self::assertSame(
             [
@@ -107,7 +105,7 @@ class BomNormalizerTest extends TestCase
                 'version' => 23,
                 'components' => ['FakeComponents'],
             ],
-            $got
+            $actual
         );
     }
 
@@ -123,7 +121,7 @@ class BomNormalizerTest extends TestCase
                 'supportsMetaData' => true,
             ]
         );
-        $metadataNormalizer = $this->createMock(MetaDataNormalizer::class);
+        $metadataNormalizer = $this->createMock(Normalizers\MetaDataNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -131,7 +129,7 @@ class BomNormalizerTest extends TestCase
                 'makeForMetaData' => $metadataNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -145,7 +143,7 @@ class BomNormalizerTest extends TestCase
             ->with($bom->getMetaData())
             ->willReturn(['FakeMetaData']);
 
-        $got = $normalizer->normalize($bom);
+        $actual = $normalizer->normalize($bom);
 
         self::assertSame(
             [
@@ -155,7 +153,7 @@ class BomNormalizerTest extends TestCase
                 'metadata' => ['FakeMetaData'],
                 'components' => [],
             ],
-            $got
+            $actual
         );
     }
 
@@ -168,7 +166,7 @@ class BomNormalizerTest extends TestCase
                 'supportsMetaData' => true,
             ]
         );
-        $metadataNormalizer = $this->createMock(MetaDataNormalizer::class);
+        $metadataNormalizer = $this->createMock(Normalizers\MetaDataNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -176,7 +174,7 @@ class BomNormalizerTest extends TestCase
                 'makeForMetaData' => $metadataNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -189,7 +187,7 @@ class BomNormalizerTest extends TestCase
             ->with($bom->getMetaData())
             ->willReturn([/* empty */]);
 
-        $got = $normalizer->normalize($bom);
+        $actual = $normalizer->normalize($bom);
 
         self::assertSame(
             [
@@ -198,7 +196,7 @@ class BomNormalizerTest extends TestCase
                 'version' => 23,
                 'components' => [],
             ],
-            $got
+            $actual
         );
     }
 
@@ -211,7 +209,7 @@ class BomNormalizerTest extends TestCase
                 'supportsMetaData' => false,
             ]
         );
-        $metadataNormalizer = $this->createMock(MetaDataNormalizer::class);
+        $metadataNormalizer = $this->createMock(Normalizers\MetaDataNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -219,7 +217,7 @@ class BomNormalizerTest extends TestCase
                 'makeForMetaData' => $metadataNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -232,7 +230,7 @@ class BomNormalizerTest extends TestCase
             ->with($bom->getMetaData())
             ->willReturn(['FakeMetaData']);
 
-        $got = $normalizer->normalize($bom);
+        $actual = $normalizer->normalize($bom);
 
         self::assertSame(
             [
@@ -241,7 +239,7 @@ class BomNormalizerTest extends TestCase
                 'version' => 23,
                 'components' => [],
             ],
-            $got
+            $actual
         );
     }
 
@@ -254,7 +252,7 @@ class BomNormalizerTest extends TestCase
                 'supportsDependencies' => true,
             ]
         );
-        $dependencyNormalizer = $this->createMock(DependenciesNormalizer::class);
+        $dependencyNormalizer = $this->createMock(Normalizers\DependenciesNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -262,7 +260,7 @@ class BomNormalizerTest extends TestCase
                 'makeForDependencies' => $dependencyNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -299,7 +297,7 @@ class BomNormalizerTest extends TestCase
                 'supportsDependencies' => true,
             ]
         );
-        $dependencyNormalizer = $this->createMock(DependenciesNormalizer::class);
+        $dependencyNormalizer = $this->createMock(Normalizers\DependenciesNormalizer::class);
         $factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
@@ -307,7 +305,7 @@ class BomNormalizerTest extends TestCase
                 'makeForDependencies' => $dependencyNormalizer,
             ]
         );
-        $normalizer = new BomNormalizer($factory);
+        $normalizer = new Normalizers\BomNormalizer($factory);
         $bom = $this->createConfiguredMock(
             Bom::class,
             [
@@ -330,6 +328,93 @@ class BomNormalizerTest extends TestCase
                 'version' => 23,
                 'components' => [],
                 // 'dependencies' is unset,
+            ],
+            $actual
+        );
+    }
+
+    public function testNormalizeExternalReferences(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.2',
+            ]
+        );
+        $externalReferenceRepositoryNormalizer = $this->createMock(Normalizers\ExternalReferenceRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForExternalReferenceRepository' => $externalReferenceRepositoryNormalizer,
+            ]
+        );
+        $normalizer = new Normalizers\BomNormalizer($factory);
+        $bom = $this->createConfiguredMock(
+            Bom::class,
+            [
+                'getVersion' => 23,
+                'getExternalReferenceRepository' => $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 1]),
+            ]
+        );
+
+        $externalReferenceRepositoryNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($bom->getExternalReferenceRepository())
+            ->willReturn(['FakeReferenceRepositoryNormalized']);
+
+        $actual = $normalizer->normalize($bom);
+
+        self::assertSame(
+            [
+                'bomFormat' => 'CycloneDX',
+                'specVersion' => '1.2',
+                'version' => 23,
+                'components' => [],
+                'externalReferences' => ['FakeReferenceRepositoryNormalized'],
+            ],
+            $actual
+        );
+    }
+
+    public function testNormalizeExternalReferencesOmitIfEmpty(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.2',
+            ]
+        );
+        $externalReferenceRepositoryNormalizer = $this->createMock(Normalizers\ExternalReferenceRepositoryNormalizer::class);
+        $factory = $this->createConfiguredMock(
+            NormalizerFactory::class,
+            [
+                'getSpec' => $spec,
+                'makeForExternalReferenceRepository' => $externalReferenceRepositoryNormalizer,
+            ]
+        );
+        $normalizer = new Normalizers\BomNormalizer($factory);
+        $bom = $this->createConfiguredMock(
+            Bom::class,
+            [
+                'getVersion' => 23,
+                'getExternalReferenceRepository' => $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 0]),
+            ]
+        );
+
+        $externalReferenceRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($bom->getExternalReferenceRepository())
+            ->willReturn(['FakeReferenceRepositoryNormalized']);
+
+        $actual = $normalizer->normalize($bom);
+
+        self::assertSame(
+            [
+                'bomFormat' => 'CycloneDX',
+                'specVersion' => '1.2',
+                'version' => 23,
+                'components' => [],
             ],
             $actual
         );

--- a/tests/Core/Serialize/JSON/Normalizers/BomNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/BomNormalizerTest.php
@@ -333,6 +333,8 @@ class BomNormalizerTest extends TestCase
         );
     }
 
+    // region normalize ExternalReferences
+
     public function testNormalizeExternalReferences(): void
     {
         $spec = $this->createConfiguredMock(
@@ -419,4 +421,6 @@ class BomNormalizerTest extends TestCase
             $actual
         );
     }
+
+    // endregion normalize ExternalReferences
 }

--- a/tests/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\HashRepository;
+use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
+use CycloneDX\Core\Serialize\JSON\Normalizers;
+use CycloneDX\Core\Spec\SpecInterface;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\JSON\Normalizers\ExternalReferenceNormalizer
+ * @covers \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+ */
+class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNormalizeTypeAndUrl(): void
+    {
+        $normalizerFactory = $this->createStub(NormalizerFactory::class);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => null,
+        ]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'someType',
+            'url' => 'someUrl',
+            // comment omitted
+            // hashes omitted
+        ], $actual);
+    }
+
+    public function testNormalizeComment(): void
+    {
+        $normalizerFactory = $this->createStub(NormalizerFactory::class);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => 'someComment',
+            'getHashRepository' => null,
+        ]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'someType',
+            'url' => 'someUrl',
+            'comment' => 'someComment',
+        ], $actual);
+    }
+
+    // region normalize hashes
+
+    public function testNormalizeHashes(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => true,
+            ]),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 1]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($extRef->getHashRepository())
+            ->willReturn(['NormalizedHashRepoFake']);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'someType',
+            'url' => 'someUrl',
+            'hashes' => ['NormalizedHashRepoFake'],
+        ], $actual);
+    }
+
+    public function testNormalizeHashesOmitIfEmpty(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => true,
+            ]),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 0]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($extRef->getHashRepository());
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'someType',
+            'url' => 'someUrl',
+            // hashes is omitted
+        ], $actual);
+    }
+
+    public function testNormalizeHashesOmitIfNotSupported(): void
+    {
+        $hashRepositoryNormalizer = $this->createMock(Normalizers\HashRepositoryNormalizer::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $this->createConfiguredMock(SpecInterface::class, [
+                'supportsExternalReferenceHashes' => false,
+            ]),
+            'makeForHashRepository' => $hashRepositoryNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getUrl' => 'someUrl',
+            'getType' => 'someType',
+            'getComment' => null,
+            'getHashRepository' => $this->createConfiguredMock(HashRepository::class, ['count' => 1]),
+        ]);
+
+        $hashRepositoryNormalizer->expects(self::never())
+            ->method('normalize')
+            ->with($extRef->getHashRepository());
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'someType',
+            'url' => 'someUrl',
+            // hashes is omitted
+        ], $actual);
+    }
+
+    // endregion normalize hashes
+}

--- a/tests/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Serialize\JSON\Normalizers;
+
+use CycloneDX\Core\Models\ExternalReference;
+use CycloneDX\Core\Repositories\ExternalReferenceRepository;
+use CycloneDX\Core\Serialize\JSON\NormalizerFactory;
+use CycloneDX\Core\Serialize\JSON\Normalizers;
+use CycloneDX\Core\Spec\SpecInterface;
+
+/**
+ * @covers \CycloneDX\Core\Serialize\JSON\Normalizers\ExternalReferenceRepositoryNormalizer
+ * @covers \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+ *
+ * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ExternalReferenceNormalizer
+ */
+class ExternalReferenceRepositoryNormalizerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
+     */
+    public function testNormalizeEmpty(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $repo = $this->createConfiguredMock(ExternalReferenceRepository::class, ['count' => 0]);
+
+        $actual = $normalizer->normalize($repo);
+
+        self::assertSame([], $actual);
+    }
+
+    public function testNormalize(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $externalReference = $this->createStub(ExternalReference::class);
+        $repo = $this->createConfiguredMock(ExternalReferenceRepository::class, [
+            'count' => 1,
+            'getExternalReferences' => [$externalReference],
+        ]);
+
+        $externalReferenceNormalizer->expects(self::once())
+            ->method('normalize')
+            ->with($externalReference)
+            ->willReturn(['FakeExtRef' => 'dummy']);
+
+        $actual = $normalizer->normalize($repo);
+
+        self::assertSame([['FakeExtRef' => 'dummy']], $actual);
+    }
+
+    public function testNormalizeSkipsOnThrow(): void
+    {
+        $spec = $this->createStub(SpecInterface::class);
+        $externalReferenceNormalizer = $this->createMock(Normalizers\ExternalReferenceNormalizer::class);
+        $factory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSpec' => $spec,
+            'makeForExternalReference' => $externalReferenceNormalizer,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceRepositoryNormalizer($factory);
+        $extRef1 = $this->createStub(ExternalReference::class);
+        $extRef2 = $this->createStub(ExternalReference::class);
+        $tools = $this->createConfiguredMock(ExternalReferenceRepository::class, [
+            'count' => 1,
+            'getExternalReferences' => [$extRef1, $extRef2],
+        ]);
+
+        $externalReferenceNormalizer->expects(self::exactly(2))->method('normalize')
+            ->withConsecutive([$extRef1], [$extRef2])
+            ->willThrowException(new \DomainException());
+
+        $actual = $normalizer->normalize($tools);
+
+        self::assertSame([], $actual);
+    }
+}

--- a/tests/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizerTest.php
@@ -37,6 +37,9 @@ use PHPUnit\Framework\TestCase;
  */
 class ToolRepositoryNormalizerTest extends TestCase
 {
+    /**
+     * @uses \CycloneDX\Core\Serialize\JSON\Normalizers\ToolNormalizer
+     */
     public function testNormalizeEmpty(): void
     {
         $spec = $this->createStub(SpecInterface::class);

--- a/tests/Core/SerializeToJsonTest.php
+++ b/tests/Core/SerializeToJsonTest.php
@@ -27,7 +27,6 @@ use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Serialize\JsonSerializer;
 use CycloneDX\Core\Spec\Spec11;
 use CycloneDX\Core\Spec\Spec12;
-use CycloneDX\Core\Spec\Spec13;
 use CycloneDX\Core\Validation\Validators\JsonStrictValidator;
 use DomainException;
 use PHPUnit\Framework\TestCase;
@@ -66,6 +65,8 @@ class SerializeToJsonTest extends TestCase
      * This test might require online-connectivity.
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
      */
     public function testSchema12(Bom $bom): void
     {
@@ -88,10 +89,12 @@ class SerializeToJsonTest extends TestCase
      * This test might require online-connectivity.
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
      */
     public function testSchema13(Bom $bom): void
     {
-        $spec = new Spec13();
+        $spec = new Spec12();
         $serializer = new JsonSerializer($spec);
         $validator = new JsonStrictValidator($spec);
 

--- a/tests/Core/SerializeToXmlTest.php
+++ b/tests/Core/SerializeToXmlTest.php
@@ -47,6 +47,8 @@ class SerializeToXmlTest extends TestCase
      * This test might require online-connectivity.
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
      */
     public function testSchema11(Bom $bom): void
     {
@@ -69,6 +71,8 @@ class SerializeToXmlTest extends TestCase
      * This test might require online-connectivity.
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
      */
     public function testSchema12(Bom $bom): void
     {
@@ -91,6 +95,8 @@ class SerializeToXmlTest extends TestCase
      * This test might require online-connectivity.
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
      */
     public function testSchema13(Bom $bom): void
     {

--- a/tests/Core/Spec/AbstractSpecTestCase.php
+++ b/tests/Core/Spec/AbstractSpecTestCase.php
@@ -26,7 +26,6 @@ namespace CycloneDX\Tests\Core\Spec;
 use CycloneDX\Core\Enums\Classification;
 use CycloneDX\Core\Enums\HashAlgorithm;
 use CycloneDX\Core\Spec\SpecInterface;
-use CycloneDX\Core\Spec\Version;
 use CycloneDX\Tests\_data\BomSpecData;
 use Generator;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +35,7 @@ abstract class AbstractSpecTestCase extends TestCase
     abstract protected function getSpec(): SpecInterface;
 
     /**
-     * @psalm-return Version::V_*
+     * @psalm-return \CycloneDX\Core\Spec\Version::V_*
      */
     abstract protected function getSpecVersion(): string;
 
@@ -61,7 +60,7 @@ abstract class AbstractSpecTestCase extends TestCase
     /**
      * @depends testKnownFormats
      */
-    public function testGetSupportedFormats(array $knownFormats): void
+    final public function testGetSupportedFormats(array $knownFormats): void
     {
         $formats = $this->getSpec()->getSupportedFormats();
         self::assertEquals($knownFormats, $formats);
@@ -190,4 +189,12 @@ abstract class AbstractSpecTestCase extends TestCase
     }
 
     abstract public function shouldSupportDependencies(): bool;
+
+    final public function testSupportsExternalReferenceHashes(): void
+    {
+        $isSupported = $this->getSpec()->supportsExternalReferenceHashes();
+        self::assertSame($this->shouldSupportExternalReferenceHashes(), $isSupported);
+    }
+
+    abstract public function shouldSupportExternalReferenceHashes(): bool;
 }

--- a/tests/Core/Spec/Spec11Test.php
+++ b/tests/Core/Spec/Spec11Test.php
@@ -66,4 +66,9 @@ class Spec11Test extends AbstractSpecTestCase
     {
         return false;
     }
+
+    public function shouldSupportExternalReferenceHashes(): bool
+    {
+        return false;
+    }
 }

--- a/tests/Core/Spec/Spec12Test.php
+++ b/tests/Core/Spec/Spec12Test.php
@@ -66,4 +66,9 @@ class Spec12Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldSupportExternalReferenceHashes(): bool
+    {
+        return false;
+    }
 }

--- a/tests/Core/Spec/Spec13Test.php
+++ b/tests/Core/Spec/Spec13Test.php
@@ -66,4 +66,9 @@ class Spec13Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldSupportExternalReferenceHashes(): bool
+    {
+        return true;
+    }
 }

--- a/tests/_data/BomSpecData.php
+++ b/tests/_data/BomSpecData.php
@@ -49,6 +49,14 @@ abstract class BomSpecData
     /**
      * @psalm-return list<string> sorted list
      */
+    public static function getExternalReferenceTypeForVersion(string $version): array
+    {
+        return self::getEnumValuesForName($version, 'externalReferenceType');
+    }
+
+    /**
+     * @psalm-return list<string> sorted list
+     */
     public static function getHashAlgEnumForVersion(string $version): array
     {
         return self::getEnumValuesForName($version, 'hashAlg');


### PR DESCRIPTION
Added Support for External References
* DataTypes related to External References:
  * `CycloneDX\Core\Models\ExternalReference`
  * `CycloneDX\Core\Repositories\ExternalReferenceRepository`
* ExternalReferences as a property of the BOM
  * `CycloneDX\Core\Models\Bom::getExternalReferenceRepository()`
  * `CycloneDX\Core\Models\Bom::setExternalReferenceRepository()`
* ExternalReferences as a property of the Component
   * `CycloneDX\Core\Models\Component::getExternalReferenceRepository()`
   * `CycloneDX\Core\Models\Component::setExternalReferenceRepository()`
* JSON serializers forExternal References
* XML serializers for External References

closes #7 
