### PR TITLE
remove url validation of `CycloneDX\Core\Models\License\AbstractDisjunctiveLicense::setUrl()`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## unreleased
+
+* Fixed
+  * `CycloneDX\Core\Models\License\AbstractDisjunctiveLicense::setUrl()` no longer restricts the argument to be a valid URL.  
+     Per schema definition `licenseType.url` should be a URI, not a URL.
+* Changed
+  * `CycloneDX\Core\Models\License\AbstractDisjunctiveLicense::setUrl()` no longer throws `InvalidArgumentException`
+     if the argument is not a URL.
+
 ## 1.0.2 - 2021-10-30
 
 * Fixed

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-dom": "*",
-        "ext-filter": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "package-url/packageurl-php": "^1.0",

--- a/src/Core/Models/License/AbstractDisjunctiveLicense.php
+++ b/src/Core/Models/License/AbstractDisjunctiveLicense.php
@@ -23,8 +23,6 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Models\License;
 
-use InvalidArgumentException;
-
 /**
  * @author jkowalleck
  *
@@ -46,15 +44,10 @@ abstract class AbstractDisjunctiveLicense
     }
 
     /**
-     * @throws InvalidArgumentException if value is an invalid URL
-     *
      * @return $this
      */
     public function setUrl(?string $url): self
     {
-        if (null !== $url && false === filter_var($url, \FILTER_VALIDATE_URL)) {
-            throw new InvalidArgumentException("Invalid URL: $url");
-        }
         $this->url = $url;
 
         return $this;

--- a/tests/Core/Models/License/AbstractDisjunctiveLicenseTestCase.php
+++ b/tests/Core/Models/License/AbstractDisjunctiveLicenseTestCase.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Models\License;
 
 use CycloneDX\Core\Models\License\AbstractDisjunctiveLicense;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,11 +44,10 @@ abstract class AbstractDisjunctiveLicenseTestCase extends TestCase
     /**
      * @depends testSetAndGetUrl
      */
-    public function testSetUrlThrows(AbstractDisjunctiveLicense $license): void
+    public function testSetUrlToSomeUri(AbstractDisjunctiveLicense $license): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/invalid URL/i');
-        $license->setUrl('foo');
+        $license->setUrl('../foo.txt');
+        self::assertSame('../foo.txt', $license->getUrl());
     }
 
     /**


### PR DESCRIPTION

fixes #18