### PR TITLE
initial spec1.4 implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,8 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ## 2.0.0 - unreleased
 
+* BREAKING changes
+  * Public interface `\CycloneDX\Core\Spec\SpecInterface` requires new methods: (via [#65])
+    * `getSupportsExternalReferenceTypes()`
+    * `isSupportsExternalReferenceType()`
+* Changed
+  * The method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` now throw `DomainException` when the `ExternalReference`'s type was not supported by the spec.  
+    This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before. (via [#65])
 * Added
-  * Support for CycloneDX v1.4 specification. (via [#65])
+  * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
+  * Spec implementations `\CycloneDX\Core\Spec\Spec1{1,2,3}`
 
 [#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,14 +7,18 @@ All notable changes to this project will be documented in this file.
 ## 2.0.0 - unreleased
 
 * BREAKING changes
-  * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])
-  
+  * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
+    This is done to prevent the need for "breaking changed"  when the schema requires additional spec implementations.
 * Changed
-  * The method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` now throw `DomainException` when the `ExternalReference`'s type was not supported by the spec.  
-    This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before. (via [#65])
+  * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
+    This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
 * Added
   * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
-  * Spec implementations `\CycloneDX\Core\Spec\Spec1{1,2,3}`
+  * New methods in class `\CycloneDX\Core\Spec\Spec1{1,2,3}` (via [#65])
+    * `::getSupportsExternalReferenceTypes()`
+    * `::isSupportsExternalReferenceType()`
+  * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` (via [#65])
+  * Support for spec v1.4 in `CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
 
 [#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## 2.0.0 - unreleased
 
+* Added
+  * Support for CycloneDX v1.4 specification. (via [#65])
+
+[#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
+
 ## 1.6.2 - 2022-09-12
 
 Maintenance release.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,9 +7,8 @@ All notable changes to this project will be documented in this file.
 ## 2.0.0 - unreleased
 
 * BREAKING changes
-  * Public interface `\CycloneDX\Core\Spec\SpecInterface` requires new methods: (via [#65])
-    * `getSupportsExternalReferenceTypes()`
-    * `isSupportsExternalReferenceType()`
+  * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])
+  
 * Changed
   * The method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` now throw `DomainException` when the `ExternalReference`'s type was not supported by the spec.  
     This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before. (via [#65])

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,17 +8,18 @@ All notable changes to this project will be documented in this file.
 
 * BREAKING changes
   * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
-    This is done to prevent the need for "breaking changed"  when the schema requires additional spec implementations.
+    This is done to prevent the need for future "breaking changed" when the schema requires additional spec implementations.
 * Changed
   * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
     This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
 * Added
+  * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` for CycloneDX v1.4. (via [#65])
   * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
+  * Support for CycloneDX v1.4 in `CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
   * New methods in class `\CycloneDX\Core\Spec\Spec1{1,2,3}` (via [#65])
     * `::getSupportsExternalReferenceTypes()`
     * `::isSupportsExternalReferenceType()`
-  * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` (via [#65])
-  * Support for spec v1.4 in `CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
+  * New class constant `CycloneDX\Core\Enums\ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4. (via [#65])
 
 [#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
 

--- a/res/README.md
+++ b/res/README.md
@@ -16,9 +16,12 @@ Currently using version
 | [`bom-1.1.SNAPSHOT.xsd`](bom-1.1.SNAPSHOT.xsd) | `http://cyclonedx.org/schema/spdx` was replaced with `spdx.SNAPSHOT.xsd` |
 | [`bom-1.2.SNAPSHOT.xsd`](bom-1.2.SNAPSHOT.xsd) | `http://cyclonedx.org/schema/spdx` was replaced with `spdx.SNAPSHOT.xsd` |
 | [`bom-1.3.SNAPSHOT.xsd`](bom-1.3.SNAPSHOT.xsd) | `http://cyclonedx.org/schema/spdx` was replaced with `spdx.SNAPSHOT.xsd` |
+| [`bom-1.4.SNAPSHOT.xsd`](bom-1.4.SNAPSHOT.xsd) | `http://cyclonedx.org/schema/spdx` was replaced with `spdx.SNAPSHOT.xsd` |
 | [`bom-1.2.SNAPSHOT.schema.json`](bom-1.2.SNAPSHOT.schema.json) | `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json` |
 | [`bom-1.3.SNAPSHOT.schema.json`](bom-1.3.SNAPSHOT.schema.json) | `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json` |
+| [`bom-1.4.SNAPSHOT.schema.json`](bom-1.4.SNAPSHOT.schema.json) | `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json` |
 | [`bom-1.2-strict.SNAPSHOT.schema.json`](bom-1.2-strict.SNAPSHOT.schema.json) | `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json` |
 | [`bom-1.3-strict.SNAPSHOT.schema.json`](bom-1.3-strict.SNAPSHOT.schema.json) | `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json` |
 | [`spdx.SNAPSHOT.xsd`](spdx.SNAPSHOT.xsd) | |
 | [`spdx.SNAPSHOT.schema.json`](spdx.SNAPSHOT.schema.json) | |
+| [`jsf-0.82.SNAPSHOT.schema.json`](jsf-0.82.SNAPSHOT.schema.json) | |

--- a/res/bom-1.4.SNAPSHOT.schema.json
+++ b/res/bom-1.4.SNAPSHOT.schema.json
@@ -1488,7 +1488,7 @@
           "type": "array",
           "title": "CWEs",
           "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability. For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
-          "examples": ["399"],
+          "examples": [399],
           "additionalItems": false,
           "items": {
             "$ref": "#/definitions/cwe"

--- a/res/bom-1.4.SNAPSHOT.schema.json
+++ b/res/bom-1.4.SNAPSHOT.schema.json
@@ -1,0 +1,1697 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "type": "object",
+  "title": "CycloneDX Software Bill of Materials Standard",
+  "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "enum": [
+        "http://cyclonedx.org/schema/bom-1.4.schema.json"
+      ]
+    },
+    "bomFormat": {
+      "type": "string",
+      "title": "BOM Format",
+      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention nor does JSON schema support namespaces. This value MUST be \"CycloneDX\".",
+      "enum": [
+        "CycloneDX"
+      ]
+    },
+    "specVersion": {
+      "type": "string",
+      "title": "CycloneDX Specification Version",
+      "description": "The version of the CycloneDX specification a BOM conforms to (starting at version 1.2).",
+      "examples": ["1.4"]
+    },
+    "serialNumber": {
+      "type": "string",
+      "title": "BOM Serial Number",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number MUST conform to RFC-4122. Use of serial numbers are RECOMMENDED.",
+      "examples": ["urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"],
+      "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "type": "integer",
+      "title": "BOM Version",
+      "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+      "default": 1,
+      "examples": [1]
+    },
+    "metadata": {
+      "$ref": "#/definitions/metadata",
+      "title": "BOM Metadata",
+      "description": "Provides additional information about a BOM."
+    },
+    "components": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/component"},
+      "uniqueItems": true,
+      "title": "Components",
+      "description": "A list of software and hardware components."
+    },
+    "services": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/service"},
+      "uniqueItems": true,
+      "title": "Services",
+      "description": "A list of services. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+    },
+    "externalReferences": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/externalReference"},
+      "title": "External References",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+    },
+    "dependencies": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/dependency"},
+      "uniqueItems": true,
+      "title": "Dependencies",
+      "description": "Provides the ability to document dependency relationships."
+    },
+    "compositions": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/compositions"},
+      "uniqueItems": true,
+      "title": "Compositions",
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {"$ref": "#/definitions/vulnerability"},
+      "uniqueItems": true,
+      "title": "Vulnerabilities",
+      "description": "Vulnerabilities identified in components or services."
+    },
+    "signature": {
+      "$ref": "#/definitions/signature",
+      "title": "Signature",
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    }
+  },
+  "definitions": {
+    "refType": {
+      "$comment": "Identifier-DataType for interlinked elements.",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "title": "BOM Metadata Object",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the BOM was created."
+        },
+        "tools": {
+          "type": "array",
+          "title": "Creation Tools",
+          "description": "The tool(s) used in the creation of the BOM.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/tool"}
+        },
+        "authors" :{
+          "type": "array",
+          "title": "Authors",
+          "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        },
+        "component": {
+          "title": "Component",
+          "description": "The component that the BOM describes.",
+          "$ref": "#/definitions/component"
+        },
+        "manufacture": {
+          "title": "Manufacture",
+          "description": "The organization that manufactured the component that the BOM describes.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "supplier": {
+          "title": "Supplier",
+          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "licenses": {
+          "type": "array",
+          "title": "BOM License(s)",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/licenseChoice"}
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "title": "Tool",
+      "description": "Information about the automated or manual tool used",
+      "additionalProperties": false,
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "title": "Tool Vendor",
+          "description": "The name of the vendor who created the tool"
+        },
+        "name": {
+          "type": "string",
+          "title": "Tool Name",
+          "description": "The name of the tool"
+        },
+        "version": {
+          "type": "string",
+          "title": "Tool Version",
+          "description": "The version of the tool"
+        },
+        "hashes": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the tool (if applicable)."
+        },
+        "externalReferences": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+        }
+      }
+    },
+    "organizationalEntity": {
+      "type": "object",
+      "title": "Organizational Entity Object",
+      "description": "",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the organization",
+          "examples": [
+            "Example Inc."
+          ]
+        },
+        "url": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "URL",
+          "description": "The URL of the organization. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        },
+        "contact": {
+          "type": "array",
+          "title": "Contact",
+          "description": "A contact at the organization. Multiple contacts are allowed.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        }
+      }
+    },
+    "organizationalContact": {
+      "type": "object",
+      "title": "Organizational Contact Object",
+      "description": "",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of a contact",
+          "examples": ["Contact name"]
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "Email Address",
+          "description": "The email address of the contact.",
+          "examples": ["firstname.lastname@example.com"]
+        },
+        "phone": {
+          "type": "string",
+          "title": "Phone",
+          "description": "The phone number of the contact.",
+          "examples": ["800-555-1212"]
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "title": "Component Object",
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "operating-system",
+            "device",
+            "firmware",
+            "file"
+          ],
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component. Types include:\n\n* __application__ = A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.\n* __framework__ = A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.\n* __library__ = A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing))\n for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is RECOMMENDED.\n* __container__ = A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization)\n* __operating-system__ = A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system)\n* __device__ = A hardware device such as a processor, or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself, and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device.\n* __firmware__ = A special type of software that provides low-level control over a devices hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware)\n* __file__ = A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+          "examples": ["library"]
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "examples": ["image/jpeg"],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "author": {
+          "type": "string",
+          "title": "Component Author",
+          "description": "The person(s) or organization(s) that authored the component",
+          "examples": ["Acme Inc"]
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "examples": ["Acme Inc"]
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "examples": ["tomcat-catalina"]
+        },
+        "version": {
+          "type": "string",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
+          "examples": ["9.0.14"]
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+          "default": "required"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/hash"}
+        },
+        "licenses": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/licenseChoice"},
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": ["Acme Inc"]
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Component Common Platform Enumeration (CPE)",
+          "description": "Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe)",
+          "examples": ["cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"]
+        },
+        "purl": {
+          "type": "string",
+          "title": "Component Package URL (purl)",
+          "description": "Specifies the package-url (purl). The purl, if specified, MUST be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec)",
+          "examples": ["pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"]
+        },
+        "swid": {
+          "$ref": "#/definitions/swid",
+          "title": "SWID Tag",
+          "description": "Specifies metadata and content for [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html)."
+        },
+        "modified": {
+          "type": "boolean",
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "additionalProperties": false,
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/commit"}
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/patch"}
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+        },
+        "components": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/component"},
+          "uniqueItems": true,
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+        },
+        "evidence": {
+          "$ref": "#/definitions/componentEvidence",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/property"}
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "swid": {
+      "type": "object",
+      "title": "SWID Tag",
+      "description": "Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.",
+      "required": [
+        "tagId",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tagId": {
+          "type": "string",
+          "title": "Tag ID",
+          "description": "Maps to the tagId of a SoftwareIdentity."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Maps to the name of a SoftwareIdentity."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "default": "0.0",
+          "description": "Maps to the version of a SoftwareIdentity."
+        },
+        "tagVersion": {
+          "type": "integer",
+          "title": "Tag Version",
+          "default": 0,
+          "description": "Maps to the tagVersion of a SoftwareIdentity."
+        },
+        "patch": {
+          "type": "boolean",
+          "title": "Patch",
+          "default": false,
+          "description": "Maps to the patch of a SoftwareIdentity."
+        },
+        "text": {
+          "title": "Attachment text",
+          "description": "Specifies the metadata and content of the SWID tag.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the SWID file.",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "title": "Attachment",
+      "description": "Specifies the metadata and content for an attachment.",
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "title": "Content-Type",
+          "description": "Specifies the content type of the text. Defaults to text/plain if not specified.",
+          "default": "text/plain"
+        },
+        "encoding": {
+          "type": "string",
+          "title": "Encoding",
+          "description": "Specifies the optional encoding the text is represented in.",
+          "enum": [
+            "base64"
+          ]
+        },
+        "content": {
+          "type": "string",
+          "title": "Attachment Text",
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+        }
+      }
+    },
+    "hash": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "alg",
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alg": {
+          "$ref": "#/definitions/hash-alg"
+        },
+        "content": {
+          "$ref": "#/definitions/hash-content"
+        }
+      }
+    },
+    "hash-alg": {
+      "type": "string",
+      "enum": [
+        "MD5",
+        "SHA-1",
+        "SHA-256",
+        "SHA-384",
+        "SHA-512",
+        "SHA3-256",
+        "SHA3-384",
+        "SHA3-512",
+        "BLAKE2b-256",
+        "BLAKE2b-384",
+        "BLAKE2b-512",
+        "BLAKE3"
+      ],
+      "title": "Hash Algorithm"
+    },
+    "hash-content": {
+      "type": "string",
+      "title": "Hash Content (value)",
+      "examples": ["3942447fac867ae5cdb3229b658f4d48"],
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+    },
+    "license": {
+      "type": "object",
+      "title": "License Object",
+      "oneOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["name"]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "spdx.SNAPSHOT.schema.json",
+          "title": "License ID (SPDX)",
+          "description": "A valid SPDX license ID",
+          "examples": ["Apache-2.0"]
+        },
+        "name": {
+          "type": "string",
+          "title": "License Name",
+          "description": "If SPDX does not define the license used, this field may be used to provide the license name",
+          "examples": ["Acme Software License"]
+        },
+        "text": {
+          "title": "License text",
+          "description": "An optional way to include the textual content of a license.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "License URL",
+          "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+          "examples": ["https://www.apache.org/licenses/LICENSE-2.0.txt"],
+          "format": "iri-reference"
+        }
+      }
+    },
+    "licenseChoice": {
+      "type": "object",
+      "title": "License(s)",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "expression": {
+          "type": "string",
+          "title": "SPDX License Expression",
+          "examples": [
+            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+            "GPL-3.0-only WITH Classpath-exception-2.0"
+          ]
+        }
+      },
+      "oneOf":[
+        {
+          "required": ["license"]
+        },
+        {
+          "required": ["expression"]
+        }
+      ]
+    },
+    "commit": {
+      "type": "object",
+      "title": "Commit",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "type": "string",
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
+          "format": "iri-reference"
+        },
+        "author": {
+          "title": "Author",
+          "description": "The author who created the changes in the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "committer": {
+          "title": "Committer",
+          "description": "The person who committed or pushed the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The text description of the contents of the commit"
+        }
+      }
+    },
+    "patch": {
+      "type": "object",
+      "title": "Patch",
+      "description": "Specifies an individual patch",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "unofficial",
+            "monkey",
+            "backport",
+            "cherry-pick"
+          ],
+          "title": "Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality.\n\n* __unofficial__ = A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch)\n* __monkey__ = A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch)\n* __backport__ = A patch which takes code from a newer version of software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting)\n* __cherry-pick__ = A patch created by selectively applying commits from other versions or branches of the same software."
+        },
+        "diff": {
+          "title": "Diff",
+          "description": "The patch file (or diff) that show changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
+          "$ref": "#/definitions/diff"
+        },
+        "resolves": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "title": "Diff",
+      "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "title": "Diff text",
+          "description": "Specifies the optional text of the diff",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "Specifies the URL to the diff",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "title": "Diff",
+      "description": "An individual issue that has been resolved.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "defect",
+            "enhancement",
+            "security"
+          ],
+          "title": "Type",
+          "description": "Specifies the type of issue"
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier of the issue assigned by the source of the issue"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the issue"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the issue"
+        },
+        "source": {
+          "type": "object",
+          "title": "Source",
+          "description": "The source of the issue where it is documented",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the source. For example 'National Vulnerability Database', 'NVD', and 'Apache'"
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
+              "format": "iri-reference"
+            }
+          }
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        }
+      }
+    },
+    "identifiableAction": {
+      "type": "object",
+      "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the individual who performed the action"
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
+        }
+      }
+    },
+    "externalReference": {
+      "type": "object",
+      "title": "External Reference",
+      "description": "Specifies an individual external reference",
+      "required": [
+        "url",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the external reference",
+          "format": "iri-reference"
+        },
+        "comment": {
+          "type": "string",
+          "title": "Comment",
+          "description": "An optional comment describing the external reference"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the type of external reference. There are built-in types to describe common references. If a type does not exist for the reference being referred to, use the \"other\" type.",
+          "enum": [
+            "vcs",
+            "issue-tracker",
+            "website",
+            "advisories",
+            "bom",
+            "mailing-list",
+            "social",
+            "chat",
+            "documentation",
+            "support",
+            "distribution",
+            "license",
+            "build-meta",
+            "build-system",
+            "release-notes",
+            "other"
+          ]
+        },
+        "hashes": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the external reference (if applicable)."
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "title": "Dependency",
+      "description": "Defines the direct dependencies of a component. Components that do not have their own dependencies MUST be declared as empty elements within the graph. Components that are not represented in the dependency graph MAY have unknown dependencies. It is RECOMMENDED that implementations assume this to be opaque and not an indicator of a component being dependency-free.",
+      "required": [
+        "ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "$ref": "#/definitions/refType",
+          "title": "Reference",
+          "description": "References a component by the components bom-ref attribute"
+        },
+        "dependsOn": {
+          "type": "array",
+          "uniqueItems": true,
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/refType"
+          },
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components that are dependencies of this dependency object."
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "title": "Service Object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "provider": {
+          "title": "Provider",
+          "description": "The organization that provides the service.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "group": {
+          "type": "string",
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "examples": ["ticker-service"]
+        },
+        "version": {
+          "type": "string",
+          "title": "Service Version",
+          "description": "The service version.",
+          "examples": ["1.0.0"]
+        },
+        "description": {
+          "type": "string",
+          "title": "Service Description",
+          "description": "Specifies a description for the service"
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "examples": ["https://example.com/api/v1/ticker"]
+        },
+        "authenticated": {
+          "type": "boolean",
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+        },
+        "x-trust-boundary": {
+          "type": "boolean",
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "data": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/dataClassification"},
+          "title": "Data Classification",
+          "description": "Specifies the data classification."
+        },
+        "licenses": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/licenseChoice"},
+          "title": "Component License(s)"
+        },
+        "externalReferences": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+        },
+        "services": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/service"},
+          "uniqueItems": true,
+          "title": "Services",
+          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/property"}
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "dataClassification": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "flow",
+        "classification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "flow": {
+          "$ref": "#/definitions/dataFlow",
+          "title": "Directional Flow",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
+        },
+        "classification": {
+          "type": "string",
+          "title": "Classification",
+          "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+        }
+      }
+    },
+    "dataFlow": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound",
+        "bi-directional",
+        "unknown"
+      ],
+      "title": "Data flow direction",
+      "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
+    },
+
+    "copyright": {
+      "type": "object",
+      "title": "Copyright",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "title": "Copyright Text"
+        }
+      }
+    },
+
+    "componentEvidence": {
+      "type": "object",
+      "title": "Evidence",
+      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
+      "additionalProperties": false,
+      "properties": {
+        "licenses": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/licenseChoice"},
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/copyright"},
+          "title": "Copyright"
+        }
+      }
+    },
+    "compositions": {
+      "type": "object",
+      "title": "Compositions",
+      "required": [
+        "aggregate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/aggregateType",
+          "title": "Aggregate",
+          "description": "Specifies an aggregate type that describe how complete a relationship is."
+        },
+        "assemblies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+        },
+        "dependencies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "aggregateType": {
+      "type": "string",
+      "default": "not_specified",
+      "enum": [
+        "complete",
+        "incomplete",
+        "incomplete_first_party_only",
+        "incomplete_third_party_only",
+        "unknown",
+        "not_specified"
+      ]
+    },
+    "property": {
+      "type": "object",
+      "title": "Lightweight name-value pair",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value of the property."
+        }
+      }
+    },
+    "localeType": {
+      "type": "string",
+      "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
+      "title": "Locale",
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code MUST be lower case. If the country code is specified, the country code MUST be upper case. The language code and country code MUST be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+    },
+    "releaseType": {
+      "type": "string",
+      "examples": [
+        "major",
+        "minor",
+        "patch",
+        "pre-release",
+        "internal"
+      ],
+      "description": "The software versioning type. It is RECOMMENDED that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+    },
+    "note": {
+      "type": "object",
+      "title": "Note",
+      "description": "A note containing the locale and content.",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "locale": {
+          "$ref": "#/definitions/localeType",
+          "title": "Locale",
+          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+        },
+        "text": {
+          "title": "Release note content",
+          "description": "Specifies the full content of the release note.",
+          "$ref": "#/definitions/attachment"
+        }
+      }
+    },
+    "releaseNotes": {
+      "type": "object",
+      "title": "Release notes",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/releaseType",
+          "title": "Type",
+          "description": "The software versioning type the release note describes."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "The title of the release."
+        },
+        "featuredImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Featured image",
+          "description": "The URL to an image that may be prominently displayed with the release note."
+        },
+        "socialImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Social image",
+          "description": "The URL to an image that may be used in messaging on social media platforms."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A short description of the release."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the release note was created."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "description": "One or more tags that may aid in search or retrieval of the release note."
+        },
+        "resolves": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues that have been resolved."
+        },
+        "notes": {
+          "type": "array",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/note"},
+          "title": "Notes",
+          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/property"}
+        }
+      }
+    },
+    "advisory": {
+      "type": "object",
+      "title": "Advisory",
+      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
+      "required": ["url"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "An optional name of the advisory."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "format": "iri-reference",
+          "description": "Location where the advisory can be obtained."
+        }
+      }
+    },
+    "cwe": {
+      "type": "integer",
+      "minimum": 1,
+      "title": "CWE",
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+    },
+    "severity": {
+      "type": "string",
+      "title": "Severity",
+      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info",
+        "none",
+        "unknown"
+      ]
+    },
+    "scoreMethod": {
+      "type": "string",
+      "title": "Method",
+      "description": "Specifies the severity or risk scoring methodology or standard used.\n\n* CVSSv2 - [Common Vulnerability Scoring System v2](https://www.first.org/cvss/v2/)\n* CVSSv3 - [Common Vulnerability Scoring System v3](https://www.first.org/cvss/v3-0/)\n* CVSSv31 - [Common Vulnerability Scoring System v3.1](https://www.first.org/cvss/v3-1/)\n* OWASP - [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology)",
+      "enum": [
+        "CVSSv2",
+        "CVSSv3",
+        "CVSSv31",
+        "OWASP",
+        "other"
+      ]
+    },
+    "impactAnalysisState": {
+      "type": "string",
+      "title": "Impact Analysis State",
+      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis. \n\n* __resolved__ = the vulnerability has been remediated. \n* __resolved\\_with\\_pedigree__ = the vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s). \n* __exploitable__ = the vulnerability may be directly or indirectly exploitable. \n* __in\\_triage__ = the vulnerability is being investigated. \n* __false\\_positive__ = the vulnerability is not specific to the component or service and was falsely identified or associated. \n* __not\\_affected__ = the component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases.",
+      "enum": [
+        "resolved",
+        "resolved_with_pedigree",
+        "exploitable",
+        "in_triage",
+        "false_positive",
+        "not_affected"
+      ]
+    },
+    "impactAnalysisJustification": {
+      "type": "string",
+      "title": "Impact Analysis Justification",
+      "description": "The rationale of why the impact analysis state was asserted. \n\n* __code\\_not\\_present__ = the code has been removed or tree-shaked. \n* __code\\_not\\_reachable__ = the vulnerable code is not invoked at runtime. \n* __requires\\_configuration__ = exploitability requires a configurable option to be set/unset. \n* __requires\\_dependency__ = exploitability requires a dependency that is not present. \n* __requires\\_environment__ = exploitability requires a certain environment which is not present. \n* __protected\\_by\\_compiler__ = exploitability requires a compiler flag to be set/unset. \n* __protected\\_at\\_runtime__ = exploits are prevented at runtime. \n* __protected\\_at\\_perimeter__ = attacks are blocked at physical, logical, or network perimeter. \n* __protected\\_by\\_mitigating\\_control__ = preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.",
+      "enum": [
+        "code_not_present",
+        "code_not_reachable",
+        "requires_configuration",
+        "requires_dependency",
+        "requires_environment",
+        "protected_by_compiler",
+        "protected_at_runtime",
+        "protected_at_perimeter",
+        "protected_by_mitigating_control"
+      ]
+    },
+    "rating": {
+      "type": "object",
+      "title": "Rating",
+      "description": "Defines the severity or risk ratings of a vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that calculated the severity or risk rating of the vulnerability."
+        },
+        "score": {
+          "type": "number",
+          "title": "Score",
+          "description": "The numerical score of the rating."
+        },
+        "severity": {
+          "$ref": "#/definitions/severity",
+          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+        },
+        "method": {
+          "$ref": "#/definitions/scoreMethod"
+        },
+        "vector": {
+          "type": "string",
+          "title": "Vector",
+          "description": "Textual representation of the metric values used to score the vulnerability"
+        },
+        "justification": {
+          "type": "string",
+          "title": "Justification",
+          "description": "An optional reason for rating the vulnerability as it was"
+        }
+      }
+    },
+    "vulnerabilitySource": {
+      "type": "object",
+      "title": "Source",
+      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The url of the vulnerability documentation as provided by the source.",
+          "examples": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the source.",
+          "examples": [
+            "NVD",
+            "National Vulnerability Database",
+            "OSS Index",
+            "VulnDB",
+            "GitHub Advisories"
+          ]
+        }
+      }
+    },
+    "vulnerability": {
+      "type": "object",
+      "title": "Vulnerability",
+      "description": "Defines a weakness in an component or service that could be exploited or triggered by a threat source.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier that uniquely identifies the vulnerability.",
+          "examples": [
+            "CVE-2021-39182",
+            "GHSA-35m5-8cvj-8783",
+            "SNYK-PYTHON-ENROCRYPT-1912876"
+          ]
+        },
+        "source": {
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that published the vulnerability."
+        },
+        "references": {
+          "type": "array",
+          "title": "References",
+          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+          "additionalItems": false,
+          "items": {
+            "required": [
+              "id",
+              "source"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "title": "ID",
+                "description": "An identifier that uniquely identifies the vulnerability.",
+                "examples": [
+                  "CVE-2021-39182",
+                  "GHSA-35m5-8cvj-8783",
+                  "SNYK-PYTHON-ENROCRYPT-1912876"
+                ]
+              },
+              "source": {
+                "$ref": "#/definitions/vulnerabilitySource",
+                "description": "The source that published the vulnerability."
+              }
+            }
+          }
+        },
+        "ratings": {
+          "type": "array",
+          "title": "Ratings",
+          "description": "List of vulnerability ratings",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/rating"
+          }
+        },
+        "cwes": {
+          "type": "array",
+          "title": "CWEs",
+          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability. For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
+          "examples": ["399"],
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/cwe"
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the vulnerability as provided by the source."
+        },
+        "detail": {
+          "type": "string",
+          "title": "Details",
+          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include examples, proof-of-concepts, and other information useful in understanding root cause."
+        },
+        "recommendation": {
+          "type": "string",
+          "title": "Details",
+          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+        },
+        "advisories": {
+          "type": "array",
+          "title": "Advisories",
+          "description": "Published advisories of the vulnerability if provided.",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/advisory"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Created",
+          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Published",
+          "description": "The date and time (timestamp) when the vulnerability record was first published."
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Updated",
+          "description": "The date and time (timestamp) when the vulnerability record was last updated."
+        },
+        "credits": {
+          "type": "object",
+          "title": "Credits",
+          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The organizations credited with vulnerability discovery.",
+              "additionalItems": false,
+              "items": {
+                "$ref": "#/definitions/organizationalEntity"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "title": "Individuals",
+              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+              "additionalItems": false,
+              "items": {
+                "$ref": "#/definitions/organizationalContact"
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "title": "Creation Tools",
+          "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+          "additionalItems": false,
+          "items": {"$ref": "#/definitions/tool"}
+        },
+        "analysis": {
+          "type": "object",
+          "title": "Impact Analysis",
+          "description": "An assessment of the impact and exploitability of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "$ref": "#/definitions/impactAnalysisState"
+            },
+            "justification": {
+              "$ref": "#/definitions/impactAnalysisJustification"
+            },
+            "response": {
+              "type": "array",
+              "title": "Response",
+              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+              "additionalItems": false,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "can_not_fix",
+                  "will_not_fix",
+                  "update",
+                  "rollback",
+                  "workaround_available"
+                ]
+              }
+            },
+            "detail": {
+              "type": "string",
+              "title": "Detail",
+              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            }
+          }
+        },
+        "affects": {
+          "type": "array",
+          "uniqueItems": true,
+          "additionalItems": false,
+          "items": {
+            "required": [
+              "ref"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "$ref": "#/definitions/refType",
+                "title": "Reference",
+                "description": "References a component or service by the objects bom-ref"
+              },
+              "versions": {
+                "type": "array",
+                "title": "Versions",
+                "description": "Zero or more individual versions or range of versions.",
+                "additionalItems": false,
+                "items": {
+                  "oneOf": [
+                    {
+                      "required": ["version"]
+                    },
+                    {
+                      "required": ["range"]
+                    }
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "version": {
+                      "description": "A single version of a component or service.",
+                      "$ref": "#/definitions/version"
+                    },
+                    "range": {
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
+                      "$ref": "#/definitions/version"
+                    },
+                    "status": {
+                      "description": "The vulnerability status for the version or range of versions.",
+                      "$ref": "#/definitions/affectedStatus",
+                      "default": "affected"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "title": "Affects",
+          "description": "The components or services that are affected by the vulnerability."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "affectedStatus": {
+      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
+      "type": "string",
+      "enum": [
+        "affected",
+        "unaffected",
+        "unknown"
+      ]
+    },
+    "version": {
+      "description": "A single version of a component or service.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "range": {
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "signature": {
+      "$ref": "jsf-0.82.SNAPSHOT.schema.json#/definitions/signature",
+      "title": "Signature",
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    }
+  }
+}

--- a/res/bom-1.4.SNAPSHOT.xsd
+++ b/res/bom-1.4.SNAPSHOT.xsd
@@ -22,7 +22,7 @@ limitations under the License.
            targetNamespace="http://cyclonedx.org/schema/bom/1.4"
            vc:minVersion="1.0"
            vc:maxVersion="1.1"
-           version="1.4.1">
+           version="1.4.2">
 
     <xs:import namespace="http://cyclonedx.org/schema/spdx" schemaLocation="spdx.SNAPSHOT.xsd"/>
 
@@ -2013,6 +2013,16 @@ limitations under the License.
                         </xs:element>
                     </xs:sequence>
                 </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
             </xs:element>
         </xs:sequence>
         <xs:attribute name="bom-ref" type="bom:refType">

--- a/res/bom-1.4.SNAPSHOT.xsd
+++ b/res/bom-1.4.SNAPSHOT.xsd
@@ -1,0 +1,2407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CycloneDX Software Bill-of-Material (SBoM) Specification
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:bom="http://cyclonedx.org/schema/bom/1.4"
+           xmlns:spdx="http://cyclonedx.org/schema/spdx"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/bom/1.4"
+           vc:minVersion="1.0"
+           vc:maxVersion="1.1"
+           version="1.4.1">
+
+    <xs:import namespace="http://cyclonedx.org/schema/spdx" schemaLocation="spdx.SNAPSHOT.xsd"/>
+
+    <xs:annotation>
+        <xs:documentation>
+            <name>CycloneDX Software Bill of Materials Standard</name>
+            <url>https://cyclonedx.org/</url>
+            <license uri="http://www.apache.org/licenses/LICENSE-2.0"
+                     version="2.0">Apache License, Version 2.0</license>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:simpleType name="refType">
+        <xs:annotation>
+            <xs:documentation>Identifier-DataType for interlinked elements.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+    <xs:complexType name="metadata">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the BOM was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used in the creation of the BOM.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="tool" minOccurs="0" type="bom:toolType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person(s) who created the BOM. Authors are common in BOMs created through
+                        manual processes. BOMs created through automated means may not have authors.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="author" type="bom:organizationalContact"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="component" type="bom:component" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The component that the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacture" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that manufactured the component that the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component that the BOM describes. The
+                        supplier may often be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="organizationalEntity">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the organization</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>The URL of the organization. Multiple URLs are allowed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="contact" type="bom:organizationalContact" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A contact person at the organization. Multiple contacts are allowed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="toolType">
+        <xs:annotation>
+            <xs:documentation>Information about the automated or manual tool used</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="vendor" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the vendor who created the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The version of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the tool.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="organizationalContact">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the contact</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The email address of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="phone" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The phone number of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="componentsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="component" type="bom:component"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="component">
+        <xs:sequence>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component. The supplier may often
+                        be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="author" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person(s) or organization(s) that authored the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="publisher" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person(s) or organization(s) that published the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name or identifier. This will often be a shortened, single
+                        name of the company or project that produced the component, or the source package or
+                        domain name. Whitespace and special characters should be avoided. Examples include:
+                        apache, org.apache.commons, and apache.org.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the component. This will often be a shortened, single name
+                        of the component. Examples: commons-lang3 and jquery</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The component version. The version should ideally comply with semantic versioning
+                        but is not enforced.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the scope of the component. If scope is not specified, 'required'
+                        scope SHOULD be assumed by the consumer of the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A copyright notice informing users of the underlying claims to
+                        copyright ownership in a published work.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cpe" type="bom:cpe" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See https://nvd.nist.gov/products/cpe
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="purl" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the package-url (purl). The purl, if specified, MUST be valid and conform
+                        to the specification defined at: https://github.com/package-url/purl-spec
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="swid" type="bom:swidType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modified" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use the pedigree
+                        element instead to supply information on exactly how the component was modified.
+                        A boolean value indicating if the component has been modified from the original.
+                        A value of true indicates the component is a derivative of the original.
+                        A value of false indicates the component has not been modified from the original.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pedigree" type="bom:pedigreeType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component pedigree is a way to document complex supply chain scenarios where components are
+                        created, distributed, modified, redistributed, combined with other components, etc.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the
+                        component or to the project the component describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="components" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of software and hardware components included in the parent component. This is not a
+                        dependency tree. It provides a way to specify a hierarchical representation of component
+                        assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="component" type="bom:component"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidence" type="bom:componentEvidenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document evidence collected through various forms of extraction or analysis.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:classification" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the type of component. For software components, classify as application if no more
+                    specific appropriate classification is available or cannot be determined for the component.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mime-type" type="bom:mimeType">
+            <xs:annotation>
+                <xs:documentation>
+                    The OPTIONAL mime-type of the component. When used on file components, the mime-type
+                    can provide additional context about the kind of file being represented such as an image,
+                    font, or executable. Some library or framework components may also have an associated mime-type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the component elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="licenseType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="id" type="spdx:licenseId" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A valid SPDX license ID</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>If SPDX does not define the license used, this field may be used to provide the license name</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the optional full text of the attachment</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the attachment file. If the attachment is a license or BOM,
+                        an externalReference should also be specified for completeness.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="attachedTextType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:annotation>
+                    <xs:documentation>The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.</xs:documentation>
+                </xs:annotation>
+                <xs:attribute name="content-type" type="xs:normalizedString" default="text/plain">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the content type of the text. Defaults to text/plain
+                            if not specified.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoding" type="bom:encoding">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the optional encoding the text is represented in
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="hashType">
+        <xs:annotation>
+            <xs:documentation>Specifies the file hash of the component</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="bom:hashValue">
+                <xs:attribute name="alg" type="bom:hashAlg" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the algorithm used to create the hash</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="scope">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="required">
+                <xs:annotation>
+                    <xs:documentation>The component is required for runtime</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="optional">
+                <xs:annotation>
+                    <xs:documentation>The component is optional at runtime. Optional components are components that
+                        are not capable of being called due to them not be installed or otherwise accessible by any means.
+                        Components that are installed but due to configuration or other restrictions are prohibited from
+                        being called must be scoped as 'required'.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="excluded">
+                <xs:annotation>
+                    <xs:documentation>Components that are excluded provide the ability to document component usage
+                        for test and other non-runtime purposes. Excluded components are not reachable within a call
+                        graph at runtime.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="classification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="application">
+                <xs:annotation>
+                    <xs:documentation>A software application. Refer to https://en.wikipedia.org/wiki/Application_software
+                        for information about applications.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="framework">
+                <xs:annotation>
+                    <xs:documentation>A software framework. Refer to https://en.wikipedia.org/wiki/Software_framework
+                        for information on how frameworks vary slightly from libraries.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="library">
+                <xs:annotation>
+                    <xs:documentation>A software library. Refer to https://en.wikipedia.org/wiki/Library_(computing)
+                        for information about libraries. All third-party and open source reusable components will likely
+                        be a library. If the library also has key features of a framework, then it should be classified
+                        as a framework. If not, or is unknown, then specifying library is recommended.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="container">
+                <xs:annotation>
+                    <xs:documentation>A packaging and/or runtime format, not specific to any particular technology,
+                        which isolates software inside the container from software outside of a container through
+                        virtualization technology. Refer to https://en.wikipedia.org/wiki/OS-level_virtualization</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="operating-system">
+                <xs:annotation>
+                    <xs:documentation>A software operating system without regard to deployment model
+                        (i.e. installed on physical hardware, virtual machine, image, etc) Refer to
+                        https://en.wikipedia.org/wiki/Operating_system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device">
+                <xs:annotation>
+                    <xs:documentation>A hardware device such as a processor, or chip-set. A hardware device
+                        containing firmware SHOULD include a component for the physical hardware itself, and another
+                        component of type 'firmware' or 'operating-system' (whichever is relevant), describing
+                        information about the software running on the device.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="firmware">
+                <xs:annotation>
+                    <xs:documentation>A special type of software that provides low-level control over a devices
+                        hardware. Refer to https://en.wikipedia.org/wiki/Firmware</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+                <xs:annotation>
+                    <xs:documentation>A computer file. Refer to https://en.wikipedia.org/wiki/Computer_file
+                        for information about files.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashAlg">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MD5"/>
+            <xs:enumeration value="SHA-1"/>
+            <xs:enumeration value="SHA-256"/>
+            <xs:enumeration value="SHA-384"/>
+            <xs:enumeration value="SHA-512"/>
+            <xs:enumeration value="SHA3-256"/>
+            <xs:enumeration value="SHA3-384"/>
+            <xs:enumeration value="SHA3-512"/>
+            <xs:enumeration value="BLAKE2b-256"/>
+            <xs:enumeration value="BLAKE2b-384"/>
+            <xs:enumeration value="BLAKE2b-512"/>
+            <xs:enumeration value="BLAKE3"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashValue">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mimeType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[-+a-z0-9.]+/[-+a-z0-9.]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encoding">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="base64"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cpe">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Define the format for acceptable CPE URIs. Supports CPE 2.2 and CPE 2.3 formats.
+                Refer to https://nvd.nist.gov/products/cpe for official specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="swidType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the full content of the SWID tag.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the SWID file.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="tagId" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagId of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the name of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="version" type="xs:string" use="optional" default="0.0">
+            <xs:annotation>
+                <xs:documentation>Maps to the version of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tagVersion" type="xs:integer" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagVersion of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="patch" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>Maps to the patch of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="urnUuid">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a string representation of a UUID conforming to RFC 4122.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="urn:uuid:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="externalReferenceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="vcs">
+                <xs:annotation>
+                    <xs:documentation>Version Control System</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="issue-tracker">
+                <xs:annotation>
+                    <xs:documentation>Issue or defect tracking system, or an Application Lifecycle Management (ALM) system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="website">
+                <xs:annotation>
+                    <xs:documentation>Website</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="advisories">
+                <xs:annotation>
+                    <xs:documentation>Security advisories</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bom">
+                <xs:annotation>
+                    <xs:documentation>Bill-of-material document (CycloneDX, SPDX, SWID, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mailing-list">
+                <xs:annotation>
+                    <xs:documentation>Mailing list or discussion group</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="social">
+                <xs:annotation>
+                    <xs:documentation>Social media account</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="chat">
+                <xs:annotation>
+                    <xs:documentation>Real-time chat platform</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="documentation">
+                <xs:annotation>
+                    <xs:documentation>Documentation, guides, or how-to instructions</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="support">
+                <xs:annotation>
+                    <xs:documentation>Community or commercial support</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="distribution">
+                <xs:annotation>
+                    <xs:documentation>Direct or repository download location</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="license">
+                <xs:annotation>
+                    <xs:documentation>The URL to the license file. If a license URL has been defined in the license
+                        node, it should also be defined as an external reference for completeness</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-meta">
+                <xs:annotation>
+                    <xs:documentation>Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-system">
+                <xs:annotation>
+                    <xs:documentation>URL to an automated build system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="release-notes">
+                <xs:annotation>
+                    <xs:documentation>URL to release notes</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Use this if no other types accurately describe the purpose of the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="externalReferences">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                External references provide a way to document systems, sites, and information that may be relevant
+                but which are not included with the BOM.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="reference" type="bom:externalReference">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Zero or more external references can be defined</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="externalReference">
+        <xs:sequence>
+            <xs:element name="url" type="xs:anyURI" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URL to the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">An optional comment describing the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:externalReferenceType" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of external reference. There are built-in types to describe common
+                    references. If a type does not exist for the reference being referred to, use the "other" type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="commitsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more commits can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="commit" type="bom:commitType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual commit.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="commitType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A unique identifier of the commit. This may be version control
+                        specific. For example, Subversion uses revision numbers whereas git uses commit hashes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URL to the commit. This URL will typically point to a commit
+                        in a version control system.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="author" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The author who created the changes in the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="committer" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The person who committed or pushed the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The text description of the contents of the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchesType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more patches can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="patch" type="bom:patchType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual patch.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchType">
+        <xs:sequence>
+            <xs:element name="diff" type="bom:diffType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The patch file (or diff) that show changes.
+                        Refer to https://en.wikipedia.org/wiki/Diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:patchClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the purpose for the patch including the resolution of defects,
+                    security issues, or new behavior or functionality</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="patchClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="unofficial">
+                <xs:annotation>
+                    <xs:documentation>A patch which is not developed by the creators or maintainers of the software
+                        being patched. Refer to https://en.wikipedia.org/wiki/Unofficial_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="monkey">
+                <xs:annotation>
+                    <xs:documentation>A patch which dynamically modifies runtime behavior.
+                        Refer to https://en.wikipedia.org/wiki/Monkey_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="backport">
+                <xs:annotation>
+                    <xs:documentation>A patch which takes code from a newer version of software and applies
+                        it to older versions of the same software. Refer to https://en.wikipedia.org/wiki/Backporting</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cherry-pick">
+                <xs:annotation>
+                    <xs:documentation>A patch created by selectively applying commits from other versions or
+                        branches of the same software.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="issueClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="defect">
+                <xs:annotation>
+                    <xs:documentation>A fault, flaw, or bug in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="enhancement">
+                <xs:annotation>
+                    <xs:documentation>A new feature or behavior in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="security">
+                <xs:annotation>
+                    <xs:documentation>A special type of defect which impacts security</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="diffType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the optional text of the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the URL to the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="issueType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual issue that has been resolved.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The identifier of the issue assigned by the source of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A description of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            The source of the issue where it is documented.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="0" type="xs:normalizedString" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The name of the source. For example "National Vulnerability Database",
+                                    "NVD", and "Apache"
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" minOccurs="0" type="xs:anyURI" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The url of the issue documentation as provided by the source
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="url" type="xs:anyURI"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:issueClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of issue</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identifiableActionType">
+        <xs:sequence>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The timestamp in which the action occurred</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The email address of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="pedigreeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Component pedigree is a way to document complex supply chain scenarios where components are created,
+                distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing
+                this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to
+                document variants where the exact relation may not be known.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="ancestors" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Describes zero or more components in which a component is derived
+                        from. This is commonly used to describe forks from existing projects where the forked version
+                        contains a ancestor node containing the original component it was forked from. For example,
+                        Component A is the original component. Component B is the component being used and documented
+                        in the BOM. However, Component B contains a pedigree node with a single ancestor documenting
+                        Component A - the original component from which Component B is derived from.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="descendants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Descendants are the exact opposite of ancestors. This provides a
+                        way to document all forks (and their forks) of an original or root component.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="variants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Variants describe relations where the relationship between the
+                        components are not known. For example, if Component A contains nearly identical code to
+                        Component B. They are both related, but it is unclear if one is derived from the other,
+                        or if they share a common ancestor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="commits" type="bom:commitsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more commits which provide a trail describing
+                        how the component deviates from an ancestor, descendant, or variant.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patches" type="bom:patchesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more patches describing how the component
+                        deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits
+                        or may be used in place of commits.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Notes, observations, and other non-structured commentary
+                        describing the components pedigree.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dependencyType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType"/>
+        </xs:sequence>
+        <xs:attribute name="ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by the its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dependenciesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType">
+                <xs:annotation>
+                    <xs:documentation>Components that do not have their own dependencies MUST be declared as empty
+                        elements within the graph. Components that are not represented in the dependency graph MAY
+                        have unknown dependencies. It is RECOMMENDED that implementations assume this to be opaque
+                        and not an indicator of a component being dependency-free.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="servicesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="service" type="bom:service"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="service">
+        <xs:sequence>
+            <xs:element name="provider" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that provides the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name, namespace, or identifier. This will often be a shortened,
+                        single name of the company or project that produced the service or domain name.
+                        Whitespace and special characters should be avoided.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the service. This will often be a shortened, single name
+                        of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The service version.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="endpoints" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="endpoint" type="xs:anyURI" minOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A service endpoint URI.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authenticated" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if the service requires authentication.
+                        A value of true indicates the service requires authentication prior to use.
+                        A value of false indicates the service does not require authentication.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="x-trust-boundary" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if use of the service crosses a trust zone or boundary.
+                        A value of true indicates that by using the service, a trust boundary is crossed.
+                        A value of false indicates that by using the service, a trust boundary is not crossed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="classification" type="bom:dataClassificationType">
+                            <xs:annotation>
+                                <xs:documentation>Specifies the data classification.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="services" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of services included or deployed behind the parent service. This is not a dependency
+                        tree. It provides a way to specify a hierarchical representation of service assemblies.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="service" type="bom:service"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the service elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataClassificationType">
+        <xs:annotation>
+            <xs:documentation>Specifies the data classification.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="flow" type="bom:dataFlowType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the flow direction of the data.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="dataFlowType">
+        <xs:annotation>
+            <xs:documentation>Specifies the flow direction of the data. Valid values are:
+                inbound, outbound, bi-directional, and unknown. Direction is relative to the service.
+                Inbound flow states that data enters the service. Outbound flow states that data
+                leaves the service. Bi-directional states that data flows both ways, and unknown
+                states that the direction is not known.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="inbound"/>
+            <xs:enumeration value="outbound"/>
+            <xs:enumeration value="bi-directional"/>
+            <xs:enumeration value="unknown"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="licenseChoiceType">
+        <xs:choice>
+            <xs:element name="license" type="bom:licenseType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="expression" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A valid SPDX license expression.
+                        Refer to https://spdx.org/specifications for syntax requirements</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="copyrightsType">
+        <xs:sequence>
+            <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="componentEvidenceType">
+        <xs:sequence>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="bom:copyrightsType" minOccurs="0" maxOccurs="1"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="composition" type="bom:compositionType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="aggregate" type="bom:aggregateType" default="not_specified">
+                <xs:annotation>
+                    <xs:documentation>Specifies an aggregate type that describe how complete a relationship is.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="assemblies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Assemblies refer to
+                        nested relationships whereby a constituent part may include other constituent parts. References
+                        do not cascade to child parts. References are explicit for the specified constituent part only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="assembly" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Dependencies refer to a
+                        relationship whereby an independent constituent part requires another independent constituent
+                        part. References do not cascade to transitive dependencies. References are explicit for the
+                        specified dependency only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="dependency" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="aggregateType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="complete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is complete. No further relationships including constituent components, services, or dependencies exist.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_specified">
+                <xs:annotation>
+                    <xs:documentation>The relationship completeness is not specified.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="localeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a syntax for representing two character language code (ISO-639) followed by an optional two
+                character country code. The language code MUST be lower case. If the country code is specified, the
+                country code MUST be upper case. The language code and country code MUST be separated by a minus sign.
+                Examples: en, en-US, fr, fr-CA
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([a-z]{2})(-[A-Z]{2})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="releaseNotesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="type" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The software versioning type. It is RECOMMENDED that the release type use one
+                        of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software
+                        release types is not practical, so standardizing on the recommended values, whenever possible,
+                        is strongly encouraged.
+                        * major = A major release may contain significant changes or may introduce breaking changes.
+                        * minor = A minor release, also known as an update, may contain a smaller number of changes than major releases.
+                        * patch = Patch releases are typically unplanned and may resolve defects or important security issues.
+                        * pre-release = A pre-release may include alpha, beta, or release candidates and typically have
+                          limited support. They provide the ability to preview a release prior to its general availability.
+                        * internal = Internal releases are not for public consumption and are intended to be used exclusively
+                          by the project or manufacturer that produced it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The title of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="featuredImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be prominently displayed with the release note.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="socialImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be used in messaging on social media platforms.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A short description of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the release note was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aliases" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="alias" type="xs:normalizedString">
+                            <xs:annotation>
+                                <xs:documentation>One or more alternate names the release may be referred to. This may
+                                include unofficial terms used by development and marketing teams (e.g. code names).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tags" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="tag" type="xs:normalizedString">
+                            <xs:annotation>
+                                <xs:documentation>One or more tags that may aid in search or retrieval of the release note.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A collection of issues that have been resolved.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="notes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="note">
+                            <xs:annotation>
+                                <xs:documentation>Zero or more release notes containing the locale and content. Multiple
+                                note elements may be specified to support release notes in a wide variety of languages.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="locale" type="bom:localeType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The ISO-639 (or higher) language code and optional ISO-3166
+                                                (or higher) country code. Examples include: "en", "en-US", "fr" and "fr-CA".</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="text" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Specifies the full content of the release note.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a key/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is OPTIONAL.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="bomReferenceType">
+        <xs:attribute name="ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by the its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="bom:propertyType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:annotation>
+            <xs:documentation>Specifies an individual property with a name and value.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The name of the property. Duplicate names are allowed, each potentially having a different value.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="vulnerability" type="bom:vulnerabilityType">
+                <xs:annotation>
+                    <xs:documentation>Defines a weakness in an component or service that could be exploited or triggered by a threat source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilityType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                        CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Zero or more pointers to vulnerabilities that are the equivalent of the
+                        vulnerability specified. Often times, the same vulnerability may exist in multiple sources of
+                        vulnerability intelligence, but have different identifiers. References provide a way to
+                        correlate vulnerabilities across multiple sources of vulnerability intelligence.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="reference">
+                            <xs:annotation>
+                                <xs:documentation>A pointer to a vulnerability that is the equivalent of the
+                                    vulnerability specified.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="1" maxOccurs="1">
+                                    <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                                                CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ratings" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">List of vulnerability ratings.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="rating" type="bom:ratingType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cwes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.
+                            For example 399 (of https://cwe.mitre.org/data/definitions/399.html)
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="cwe" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A description of the vulnerability as provided by the source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>If available, an in-depth description of the vulnerability as provided by the
+                        source organization. Details often include examples, proof-of-concepts, and other information
+                        useful in understanding root cause.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="recommendation" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Recommendations of how the vulnerability can be remediated or mitigated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="advisories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Published advisories of the vulnerability if provided.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="advisory" type="bom:advisoryType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="created" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was created in the vulnerability database.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="published" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was first published.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="updated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was last updated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="credits" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Individuals or organizations credited with the discovery of the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="organizations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The organizations credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="organization" type="bom:organizationalEntity"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="individuals" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individuals, not associated with organizations, that are credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="individual" type="bom:organizationalContact"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used to identify, confirm, or score the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="tool" minOccurs="0" type="bom:toolType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="analysis" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            An assessment of the impact and exploitability of the vulnerability.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                        <xs:element name="state" type="bom:impactAnalysisStateType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="justification" type="bom:impactAnalysisJustificationType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The rationale of why the impact analysis state was asserted.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="responses" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A response to the vulnerability by the manufacturer, supplier, or
+                                    project responsible for the affected component or service. More than one response
+                                    is allowed. Responses are strongly encouraged for vulnerabilities where the analysis
+                                    state is exploitable.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="response" type="bom:impactAnalysisResponsesType"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Detailed description of the impact including methods used during assessment.
+                                    If a vulnerability is not exploitable, this field should include specific details
+                                    on why the component or service is not impacted by this vulnerability.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="affects" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The components or services that are affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="target">
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="1">
+                                    <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>References a component or service by the objects bom-ref.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="versions" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Zero or more individual versions or range of versions.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="version">
+                                                    <xs:complexType>
+                                                        <xs:sequence minOccurs="0" maxOccurs="1">
+                                                            <xs:choice>
+                                                                <xs:element name="version" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A single version of a component or service.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                                <xs:element name="range" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                            </xs:choice>
+                                                            <xs:element name="status" type="bom:impactAnalysisAffectedStatusType" minOccurs="0" maxOccurs="1" default="affected">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The vulnerability status for the version or range of versions.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the vulnerability elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitySourceType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the source.
+                        For example: NVD, National Vulnerability Database, OSS Index, VulnDB, and GitHub Advisories
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The url of the vulnerability documentation as provided by the source.
+                    For example: https://nvd.nist.gov/vuln/detail/CVE-2021-39182</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ratingType">
+        <xs:sequence>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that calculated the severity or risk rating of the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="score" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="severity" type="bom:severityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the severity that corresponds to the numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="method" type="bom:scoreSourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The risk scoring methodology/standard used.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="vector" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the metric values used to score the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="justification" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>An optional reason for rating the vulnerability as it was.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="advisoryType">
+        <xs:sequence>
+            <xs:element name="title" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>An optional name of the advisory.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Location where the advisory can be obtained.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="severityType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Textual representation of the severity of the vulnerability adopted by the analysis method. If the
+                analysis method uses values other than what is provided, the user is expected to translate appropriately.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="critical"/>
+            <xs:enumeration value="high"/>
+            <xs:enumeration value="medium"/>
+            <xs:enumeration value="low"/>
+            <xs:enumeration value="info"/>
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="unknown"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisStateType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="resolved">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="resolved_with_pedigree">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated and evidence of the changes are provided in the affected
+                        components pedigree containing verifiable commit history and/or diff(s).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exploitable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability may be directly or indirectly exploitable.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="in_triage">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is being investigated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="false_positive">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is not specific to the component or service and was falsely identified or associated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_affected">
+                <xs:annotation>
+                    <xs:documentation>
+                        The component or service is not affected by the vulnerability. Justification should be specified
+                        for all not_affected cases.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisJustificationType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="code_not_present">
+                <xs:annotation>
+                    <xs:documentation>
+                        The code has been removed or tree-shaked.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="code_not_reachable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerable code is not invoked at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_configuration">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a configurable option to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_dependency">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a dependency that is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_environment">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a certain environment which is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_compiler">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a compiler flag to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_runtime">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploits are prevented at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_perimeter">
+                <xs:annotation>
+                    <xs:documentation>
+                        Attacks are blocked at physical, logical, or network perimeter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_mitigating_control">
+                <xs:annotation>
+                    <xs:documentation>
+                        Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="scoreSourceType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Specifies the severity or risk scoring methodology or standard used.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CVSSv2">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The rating is based on CVSS v2 standard
+                        https://www.first.org/cvss/v2/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv3">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The rating is based on CVSS v3.0 standard
+                        https://www.first.org/cvss/v3-0/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv31">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The rating is based on CVSS v3.1 standard
+                        https://www.first.org/cvss/v3-1/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OWASP">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The rating is based on OWASP Risk Rating
+                        https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Use this if the risk scoring methodology is not based on any of the options above
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisResponsesType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="can_not_fix"/>
+            <xs:enumeration value="will_not_fix"/>
+            <xs:enumeration value="update"/>
+            <xs:enumeration value="rollback"/>
+            <xs:enumeration value="workaround_available"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisAffectedStatusType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The vulnerability status of a given version or range of versions of a product. The statuses
+                'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability.
+                The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected.
+                There can be many reasons for an 'unknown' status, including that an investigation has not been
+                undertaken or that a vendor has not disclosed the status.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="affected"/>
+            <xs:enumeration value="unaffected"/>
+            <xs:enumeration value="unknown"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:element name="bom">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="metadata" type="bom:metadata" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides additional information about a BOM.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of software and hardware components.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of services. This may include microservices, function-as-a-service, and other types of network or intra-process services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document external references related to the BOM or
+                            to the project the BOM describes.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dependencies" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document dependency relationships.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="compositions" type="bom:compositionsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document properties in a key/value store.
+                            This provides flexibility to include data not officially supported in the standard
+                            without having to use additional namespaces or create extensions. Property names
+                            of interest to the general public are encouraged to be registered in the
+                            CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                            Formal registration is OPTIONAL.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="vulnerabilities" type="bom:vulnerabilitiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Vulnerabilities identified in components or services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Allows any undeclared elements as long as the elements are placed in a different namespace.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:integer" default="1">
+                <xs:annotation>
+                    <xs:documentation>Whenever an existing BOM is modified, either manually or through automated
+                        processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with
+                        multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM.
+                        The default version is '1'.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="serialNumber" type="bom:urnUuid">
+                <xs:annotation>
+                    <xs:documentation>Every BOM generated SHOULD have a unique serial number, even if the contents of
+                        the BOM have not changed over time. If specified, the serial number MUST conform to RFC-4122.
+                        Use of serial numbers are RECOMMENDED.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:anyAttribute namespace="##any" processContents="lax">
+                <xs:annotation>
+                    <xs:documentation>User-defined attributes may be used on this element as long as they
+                        do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                </xs:annotation>
+            </xs:anyAttribute>
+        </xs:complexType>
+        <xs:unique name="bom-ref">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@bom-ref"/>
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/res/jsf-0.82.SNAPSHOT.schema.json
+++ b/res/jsf-0.82.SNAPSHOT.schema.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://cyclonedx.org/schema/jsf-0.82.schema.json",
+  "type": "object",
+  "title": "JSON Signature Format (JSF) standard",
+  "$comment" : "JSON Signature Format schema is published under the terms of the Apache License 2.0. JSF was developed by Anders Rundgren (anders.rundgren.net@gmail.com) as a part of the OpenKeyStore project. This schema supports the entirely of the JSF standard excluding 'extensions'.",
+  "definitions": {
+    "signature": {
+      "type": "object",
+      "title": "Signature",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "signers": {
+              "type": "array",
+              "title": "Signature",
+              "description": "Unique top level property for Multiple Signatures. (multisignature)",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/signer"}
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "chain": {
+              "type": "array",
+              "title": "Signature",
+              "description": "Unique top level property for Signature Chains. (signaturechain)",
+              "additionalItems": false,
+              "items": {"$ref": "#/definitions/signer"}
+            }
+          }
+        },
+        {
+          "title": "Signature",
+          "description": "Unique top level property for simple signatures. (signaturecore)",
+          "$ref": "#/definitions/signer"
+        }
+      ]
+    },
+    "signer": {
+      "type": "object",
+      "title": "Signature",
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Algorithm",
+              "description": "Signature algorithm. The currently recognized JWA [RFC7518] and RFC8037 [RFC8037] asymmetric key algorithms. Note: Unlike RFC8037 [RFC8037] JSF requires explicit Ed* algorithm names instead of \"EdDSA\".",
+              "enum": [
+                "RS256",
+                "RS384",
+                "RS512",
+                "PS256",
+                "PS384",
+                "PS512",
+                "ES256",
+                "ES384",
+                "ES512",
+                "Ed25519",
+                "Ed448",
+                "HS256",
+                "HS384",
+                "HS512"
+              ]
+            },
+            {
+              "type": "string",
+              "title": "Algorithm",
+              "description": "Signature algorithm. Note: If proprietary signature algorithms are added, they must be expressed as URIs.",
+              "format": "uri"
+            }
+          ]
+        },
+        "keyId": {
+          "type": "string",
+          "title": "Key ID",
+          "description": "Optional. Application specific string identifying the signature key."
+        },
+        "publicKey": {
+          "title": "Public key",
+          "description": "Optional. Public key object.",
+          "$ref": "#/definitions/publicKey"
+        },
+        "certificatePath": {
+          "type": "array",
+          "title": "Certificate path",
+          "description": "Optional. Sorted array of X.509 [RFC5280] certificates, where the first element must contain the signature certificate. The certificate path must be contiguous but is not required to be complete.",
+          "additionalItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludes": {
+          "type": "array",
+          "title": "Excludes",
+          "description": "Optional. Array holding the names of one or more application level properties that must be excluded from the signature process. Note that the \"excludes\" property itself, must also be excluded from the signature process. Since both the \"excludes\" property and the associated data it points to are unsigned, a conforming JSF implementation must provide options for specifying which properties to accept.",
+          "additionalItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+        "value": {
+          "type": "string",
+          "title": "Signature",
+          "description": "The signature data. Note that the binary representation must follow the JWA [RFC7518] specifications."
+        }
+      }
+    },
+    "keyType": {
+      "type": "string",
+      "title": "Key type",
+      "description": "Key type indicator.",
+      "enum": [
+        "EC",
+        "OKP",
+        "RSA"
+      ]
+    },
+    "publicKey": {
+      "title": "Public key",
+      "description": "Optional. Public key object.",
+      "type": "object",
+      "required": [
+        "kty"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "kty": {
+          "$ref": "#/definitions/keyType"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kty": { "const": "EC" } }
+          },
+          "then": {
+            "required": [
+              "kty",
+              "crv",
+              "x",
+              "y"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "kty": {
+                "$ref": "#/definitions/keyType"
+              },
+              "crv": {
+                "type": "string",
+                "title": "Curve name",
+                "description": "EC curve name.",
+                "enum": [
+                  "P-256",
+                  "P-384",
+                  "P-521"
+                ]
+              },
+              "x": {
+                "type": "string",
+                "title": "Coordinate",
+                "description": "EC curve point X. The length of this field must be the full size of a coordinate for the curve specified in the \"crv\" parameter. For example, if the value of \"crv\" is \"P-521\", the decoded argument must be 66 bytes."
+              },
+              "y": {
+                "type": "string",
+                "title": "Coordinate",
+                "description": "EC curve point Y. The length of this field must be the full size of a coordinate for the curve specified in the \"crv\" parameter. For example, if the value of \"crv\" is \"P-256\", the decoded argument must be 32 bytes."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "kty": { "const": "OKP" } }
+          },
+          "then": {
+            "required": [
+              "kty",
+              "crv",
+              "x"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "kty": {
+                "$ref": "#/definitions/keyType"
+              },
+              "crv": {
+                "type": "string",
+                "title": "Curve name",
+                "description": "EdDSA curve name.",
+                "enum": [
+                  "Ed25519",
+                  "Ed448"
+                ]
+              },
+              "x": {
+                "type": "string",
+                "title": "Coordinate",
+                "description": "EdDSA curve point X. The length of this field must be the full size of a coordinate for the curve specified in the \"crv\" parameter. For example, if the value of \"crv\" is \"Ed25519\", the decoded argument must be 32 bytes."
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "kty": { "const": "RSA" } }
+          },
+          "then": {
+            "required": [
+              "kty",
+              "n",
+              "e"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "kty": {
+                "$ref": "#/definitions/keyType"
+              },
+              "n": {
+                "type": "string",
+                "title": "Modulus",
+                "description": "RSA modulus."
+              },
+              "e": {
+                "type": "string",
+                "title": "Exponent",
+                "description": "RSA exponent."
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Core/Enums/Classification.php
+++ b/src/Core/Enums/Classification.php
@@ -30,6 +30,7 @@ namespace CycloneDX\Core\Enums;
  * See {@link https://cyclonedx.org/schema/bom/1.1 Schema 1.1} for `classification`.
  * See {@link https://cyclonedx.org/schema/bom/1.2 Schema 1.2} for `classification`.
  * See {@link https://cyclonedx.org/schema/bom/1.3 Schema 1.3} for `classification`.
+ * See {@link https://cyclonedx.org/schema/bom/1.4 Schema 1.4} for `classification`.
  *
  * @author jkowalleck
  */

--- a/src/Core/Enums/ExternalReferenceType.php
+++ b/src/Core/Enums/ExternalReferenceType.php
@@ -60,6 +60,8 @@ abstract class ExternalReferenceType
     public const BUILD_META = 'build-meta';
     /** URL to an automated build system. */
     public const BUILD_SYSTEM = 'build-system';
+    /** URL to release notes. */
+    public const RELEASE_NOTES = 'release-notes';
     /** Use this if no other types accurately describe the purpose of the external reference. */
     public const OTHER = 'other';
 

--- a/src/Core/Enums/ExternalReferenceType.php
+++ b/src/Core/Enums/ExternalReferenceType.php
@@ -27,6 +27,7 @@ namespace CycloneDX\Core\Enums;
  * See {@link https://cyclonedx.org/schema/bom/1.1 Schema 1.1} for `externalReferenceType`.
  * See {@link https://cyclonedx.org/schema/bom/1.2 Schema 1.2} for `externalReferenceType`.
  * See {@link https://cyclonedx.org/schema/bom/1.3 Schema 1.3} for `externalReferenceType`.
+ * See {@link https://cyclonedx.org/schema/bom/1.4 Schema 1.4} for `externalReferenceType`.
  *
  * @author jkowalleck
  */

--- a/src/Core/Enums/HashAlgorithm.php
+++ b/src/Core/Enums/HashAlgorithm.php
@@ -28,6 +28,7 @@ namespace CycloneDX\Core\Enums;
  * See {@link https://cyclonedx.org/schema/bom/1.1 Schema 1.1} for `hashAlg`.
  * See {@link https://cyclonedx.org/schema/bom/1.2 Schema 1.2} for `hashAlg`.
  * See {@link https://cyclonedx.org/schema/bom/1.3 Schema 1.3} for `hashAlg`.
+ * See {@link https://cyclonedx.org/schema/bom/1.4 Schema 1.4} for `hashAlg`.
  *
  * @author jkowalleck
  */

--- a/src/Core/Helpers/NullAssertionTrait.php
+++ b/src/Core/Helpers/NullAssertionTrait.php
@@ -26,7 +26,7 @@ namespace CycloneDX\Core\Helpers;
 /**
  * @author jkowalleck
  *
- * @internal
+ * @internal This trait may be affected by breaking changes without notice.
  */
 trait NullAssertionTrait
 {

--- a/src/Core/Helpers/NullAssertionTrait.php
+++ b/src/Core/Helpers/NullAssertionTrait.php
@@ -26,7 +26,7 @@ namespace CycloneDX\Core\Helpers;
 /**
  * @author jkowalleck
  *
- * @internal This trait may be affected by breaking changes without notice.
+ * @internal as this trait may be affected by breaking changes without notice
  */
 trait NullAssertionTrait
 {

--- a/src/Core/Helpers/SimpleDomTrait.php
+++ b/src/Core/Helpers/SimpleDomTrait.php
@@ -28,7 +28,7 @@ use DOMElement;
 use DOMNode;
 
 /**
- * @internal This trait may be affected by breaking changes without notice.
+ * @internal as this trait may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Helpers/SimpleDomTrait.php
+++ b/src/Core/Helpers/SimpleDomTrait.php
@@ -28,7 +28,7 @@ use DOMElement;
 use DOMNode;
 
 /**
- * @internal
+ * @internal This trait may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Helpers/XmlTrait.php
+++ b/src/Core/Helpers/XmlTrait.php
@@ -28,7 +28,7 @@ use DOMDocument;
 /**
  * @author jkowalleck
  *
- * @internal
+ * @internal This trait may be affected by breaking changes without notice.
  */
 trait XmlTrait
 {

--- a/src/Core/Helpers/XmlTrait.php
+++ b/src/Core/Helpers/XmlTrait.php
@@ -28,7 +28,7 @@ use DOMDocument;
 /**
  * @author jkowalleck
  *
- * @internal This trait may be affected by breaking changes without notice.
+ * @internal as this trait may be affected by breaking changes without notice
  */
 trait XmlTrait
 {

--- a/src/Core/Models/BomRef.php
+++ b/src/Core/Models/BomRef.php
@@ -24,12 +24,12 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Models;
 
 /**
- * An identifier which can be used to reference objects elsewhere in the BOM.
+ * Identifier-DataType for interlinked elements.
+ *
+ * Class is currently final, to enforce proper usage.
  *
  * Implementation is intended to prevent memory leaks.
  * See ../../../docs/dev/decisions/BomDependencyDataModel.md
- *
- * Class is currently final, to enforce proper usage.
  *
  * @author jkowalleck
  */

--- a/src/Core/Models/License/AbstractDisjunctiveLicense.php
+++ b/src/Core/Models/License/AbstractDisjunctiveLicense.php
@@ -26,7 +26,7 @@ namespace CycloneDX\Core\Models\License;
 /**
  * @author jkowalleck
  *
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  */
 abstract class AbstractDisjunctiveLicense
 {

--- a/src/Core/Models/License/AbstractDisjunctiveLicense.php
+++ b/src/Core/Models/License/AbstractDisjunctiveLicense.php
@@ -26,7 +26,7 @@ namespace CycloneDX\Core\Models\License;
 /**
  * @author jkowalleck
  *
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  */
 abstract class AbstractDisjunctiveLicense
 {

--- a/src/Core/Resources.php
+++ b/src/Core/Resources.php
@@ -39,6 +39,7 @@ final class Resources
     public const FILE_CDX_XML_SCHEMA_1_1 = __DIR__.'/../../res/bom-1.1.SNAPSHOT.xsd';
     public const FILE_CDX_XML_SCHEMA_1_2 = __DIR__.'/../../res/bom-1.2.SNAPSHOT.xsd';
     public const FILE_CDX_XML_SCHEMA_1_3 = __DIR__.'/../../res/bom-1.3.SNAPSHOT.xsd';
+    public const FILE_CDX_XML_SCHEMA_1_4 = __DIR__.'/../../res/bom-1.4.SNAPSHOT.xsd';
 
     // v1.0 is not defined in JSON
     // v1.1 is not defined in JSON

--- a/src/Core/Resources.php
+++ b/src/Core/Resources.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core;
 
 /**
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Resources.php
+++ b/src/Core/Resources.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core;
 
 /**
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Resources.php
+++ b/src/Core/Resources.php
@@ -30,22 +30,30 @@ namespace CycloneDX\Core;
  */
 final class Resources
 {
-    // paths are a concat of `__DIR__` and a relative path,
+    // ANY path is a concat of `__DIR__` and a relative path,
     // so IDEs are able to refactor paths easily.
 
     public const ROOT = __DIR__.'/../../res/';
-
-    public const FILE_SPDX_XML_SCHEMA = __DIR__.'/../../res/spdx.SNAPSHOT.xsd';
-    public const FILE_SPDX_JSON_SCHEMA = __DIR__.'/../../res/spdx.SNAPSHOT.schema.json';
 
     public const FILE_CDX_XML_SCHEMA_1_0 = __DIR__.'/../../res/bom-1.0.SNAPSHOT.xsd';
     public const FILE_CDX_XML_SCHEMA_1_1 = __DIR__.'/../../res/bom-1.1.SNAPSHOT.xsd';
     public const FILE_CDX_XML_SCHEMA_1_2 = __DIR__.'/../../res/bom-1.2.SNAPSHOT.xsd';
     public const FILE_CDX_XML_SCHEMA_1_3 = __DIR__.'/../../res/bom-1.3.SNAPSHOT.xsd';
 
+    // v1.0 is not defined in JSON
+    // v1.1 is not defined in JSON
     public const FILE_CDX_JSON_SCHEMA_1_2 = __DIR__.'/../../res/bom-1.2.SNAPSHOT.schema.json';
     public const FILE_CDX_JSON_SCHEMA_1_3 = __DIR__.'/../../res/bom-1.3.SNAPSHOT.schema.json';
+    public const FILE_CDX_JSON_SCHEMA_1_4 = __DIR__.'/../../res/bom-1.4.SNAPSHOT.schema.json';
 
+    // v1.0 is not defined in JSON
+    // v1.1 is not defined in JSON
     public const FILE_CDX_JSON_STRICT_SCHEMA_1_2 = __DIR__.'/../../res/bom-1.2-strict.SNAPSHOT.schema.json';
     public const FILE_CDX_JSON_STRICT_SCHEMA_1_3 = __DIR__.'/../../res/bom-1.3-strict.SNAPSHOT.schema.json';
+    // v1.4 is already strict - no special file here
+
+    public const FILE_SPDX_XML_SCHEMA = __DIR__.'/../../res/spdx.SNAPSHOT.xsd';
+    public const FILE_SPDX_JSON_SCHEMA = __DIR__.'/../../res/spdx.SNAPSHOT.schema.json';
+
+    public const FILE_JSF_JSON_SCHEMA = __DIR__.'/../../res/jsf-0.82.SNAPSHOT.schema.json';
 }

--- a/src/Core/Serialize/DOM/AbstractNormalizer.php
+++ b/src/Core/Serialize/DOM/AbstractNormalizer.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialize\DOM;
 
 /**
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Serialize/DOM/AbstractNormalizer.php
+++ b/src/Core/Serialize/DOM/AbstractNormalizer.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialize\DOM;
 
 /**
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Serialize/JSON/AbstractNormalizer.php
+++ b/src/Core/Serialize/JSON/AbstractNormalizer.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialize\JSON;
 
 /**
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Serialize/JSON/AbstractNormalizer.php
+++ b/src/Core/Serialize/JSON/AbstractNormalizer.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialize\JSON;
 
 /**
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ExternalReferenceNormalizer.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Helpers\NullAssertionTrait;
 use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Repositories\HashRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
+use DomainException;
 
 /**
  * @author jkowalleck
@@ -36,15 +37,18 @@ class ExternalReferenceNormalizer extends AbstractNormalizer
     use NullAssertionTrait;
 
     /**
-     * @throws \DomainException
+     * @throws DomainException when the type was not supported by the spec
      */
     public function normalize(ExternalReference $externalReference): array
     {
-        // could throw DomainException if the type was not supported
+        $type = $externalReference->getType();
+        if (false === $this->getNormalizerFactory()->getSpec()->isSupportsExternalReferenceType($type)) {
+            throw new DomainException("ExternalReference has unsupported type: $type");
+        }
 
         return array_filter(
             [
-                'type' => $externalReference->getType(),
+                'type' => $type,
                 'url' => $externalReference->getUrl(),
                 'comment' => $externalReference->getComment(),
                 'hashes' => $this->normalizeHashes($externalReference->getHashRepository()),

--- a/src/Core/Serialize/JsonSerializer.php
+++ b/src/Core/Serialize/JsonSerializer.php
@@ -51,6 +51,7 @@ class JsonSerializer extends BaseSerializer
         Version::V_1_1 => null, // unsupported version
         Version::V_1_2 => 'http://cyclonedx.org/schema/bom-1.2a.schema.json',
         Version::V_1_3 => 'http://cyclonedx.org/schema/bom-1.3.schema.json',
+        Version::V_1_4 => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
     ];
 
     private function getSchemaBase(): array

--- a/src/Core/Spec/Format.php
+++ b/src/Core/Spec/Format.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 /**
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Spec/Format.php
+++ b/src/Core/Spec/Format.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 /**
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Spec/Spec11.php
+++ b/src/Core/Spec/Spec11.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -56,6 +57,24 @@ final class Spec11 implements SpecInterface
         HashAlgorithm::SHA_512,
         HashAlgorithm::SHA3_256,
         HashAlgorithm::SHA3_512,
+    ];
+
+    private const EXTERNAL_REFERENCE_TYPES = [
+        ExternalReferenceType::VCS,
+        ExternalReferenceType::ISSUE_TRACKER,
+        ExternalReferenceType::WEBSITE,
+        ExternalReferenceType::ADVISORIES,
+        ExternalReferenceType::BOM,
+        ExternalReferenceType::MAILING_LIST,
+        ExternalReferenceType::SOCIAL,
+        ExternalReferenceType::CHAT,
+        ExternalReferenceType::DOCUMENTATION,
+        ExternalReferenceType::SUPPORT,
+        ExternalReferenceType::DISTRIBUTION,
+        ExternalReferenceType::LICENSE,
+        ExternalReferenceType::BUILD_META,
+        ExternalReferenceType::BUILD_SYSTEM,
+        ExternalReferenceType::OTHER,
     ];
 
     private const HASH_CONTENT_REGEX = '/^(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$/';

--- a/src/Core/Spec/Spec12.php
+++ b/src/Core/Spec/Spec12.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -64,6 +65,24 @@ final class Spec12 implements SpecInterface
         HashAlgorithm::BLAKE2B_384,
         HashAlgorithm::BLAKE2B_512,
         HashAlgorithm::BLAKE3,
+    ];
+
+    private const EXTERNAL_REFERENCE_TYPES = [
+        ExternalReferenceType::VCS,
+        ExternalReferenceType::ISSUE_TRACKER,
+        ExternalReferenceType::WEBSITE,
+        ExternalReferenceType::ADVISORIES,
+        ExternalReferenceType::BOM,
+        ExternalReferenceType::MAILING_LIST,
+        ExternalReferenceType::SOCIAL,
+        ExternalReferenceType::CHAT,
+        ExternalReferenceType::DOCUMENTATION,
+        ExternalReferenceType::SUPPORT,
+        ExternalReferenceType::DISTRIBUTION,
+        ExternalReferenceType::LICENSE,
+        ExternalReferenceType::BUILD_META,
+        ExternalReferenceType::BUILD_SYSTEM,
+        ExternalReferenceType::OTHER,
     ];
 
     private const HASH_CONTENT_REGEX = '/^(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$/';

--- a/src/Core/Spec/Spec13.php
+++ b/src/Core/Spec/Spec13.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -64,6 +65,24 @@ final class Spec13 implements SpecInterface
         HashAlgorithm::BLAKE2B_384,
         HashAlgorithm::BLAKE2B_512,
         HashAlgorithm::BLAKE3,
+    ];
+
+    private const EXTERNAL_REFERENCE_TYPES = [
+        ExternalReferenceType::VCS,
+        ExternalReferenceType::ISSUE_TRACKER,
+        ExternalReferenceType::WEBSITE,
+        ExternalReferenceType::ADVISORIES,
+        ExternalReferenceType::BOM,
+        ExternalReferenceType::MAILING_LIST,
+        ExternalReferenceType::SOCIAL,
+        ExternalReferenceType::CHAT,
+        ExternalReferenceType::DOCUMENTATION,
+        ExternalReferenceType::SUPPORT,
+        ExternalReferenceType::DISTRIBUTION,
+        ExternalReferenceType::LICENSE,
+        ExternalReferenceType::BUILD_META,
+        ExternalReferenceType::BUILD_SYSTEM,
+        ExternalReferenceType::OTHER,
     ];
 
     private const HASH_CONTENT_REGEX = '/^(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$/';

--- a/src/Core/Spec/Spec14.php
+++ b/src/Core/Spec/Spec14.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Core\Spec;
+
+use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\HashAlgorithm;
+
+/**
+ * @author jkowalleck
+ */
+final class Spec14 implements SpecInterface
+{
+    use SpecTrait;
+
+    private const VERSION = Version::V_1_4;
+
+    private const FORMATS = [
+        Format::XML,
+        Format::JSON,
+    ];
+
+    // @TODO
+    private const COMPONENT_TYPES = [
+        Classification::APPLICATION,
+        Classification::FRAMEWORK,
+        Classification::LIBRARY,
+        Classification::OPERATING_SYSTEMS,
+        Classification::DEVICE,
+        Classification::FILE,
+        Classification::CONTAINER,
+        Classification::FIRMWARE,
+    ];
+
+    // @TODO
+    private const HASH_ALGORITHMS = [
+        HashAlgorithm::MD5,
+        HashAlgorithm::SHA_1,
+        HashAlgorithm::SHA_256,
+        HashAlgorithm::SHA_384,
+        HashAlgorithm::SHA_512,
+        HashAlgorithm::SHA3_256,
+        HashAlgorithm::SHA3_384,
+        HashAlgorithm::SHA3_512,
+        HashAlgorithm::BLAKE2B_256,
+        HashAlgorithm::BLAKE2B_384,
+        HashAlgorithm::BLAKE2B_512,
+        HashAlgorithm::BLAKE3,
+    ];
+
+    // @TODO
+    private const HASH_CONTENT_REGEX = '/^(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$/';
+
+    public function supportsLicenseExpression(): bool
+    {
+        return true;
+    }
+
+    public function supportsMetaData(): bool
+    {
+        return true;
+    }
+
+    public function supportsBomRef(): bool
+    {
+        return true;
+    }
+
+    public function supportsDependencies(): bool
+    {
+        return true;
+    }
+
+    public function supportsExternalReferenceHashes(): bool
+    {
+        return true;
+    }
+}

--- a/src/Core/Spec/Spec14.php
+++ b/src/Core/Spec/Spec14.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -66,6 +67,25 @@ final class Spec14 implements SpecInterface
         HashAlgorithm::BLAKE2B_384,
         HashAlgorithm::BLAKE2B_512,
         HashAlgorithm::BLAKE3,
+    ];
+
+    private const EXTERNAL_REFERENCE_TYPES = [
+        ExternalReferenceType::VCS,
+        ExternalReferenceType::ISSUE_TRACKER,
+        ExternalReferenceType::WEBSITE,
+        ExternalReferenceType::ADVISORIES,
+        ExternalReferenceType::BOM,
+        ExternalReferenceType::MAILING_LIST,
+        ExternalReferenceType::SOCIAL,
+        ExternalReferenceType::CHAT,
+        ExternalReferenceType::DOCUMENTATION,
+        ExternalReferenceType::SUPPORT,
+        ExternalReferenceType::DISTRIBUTION,
+        ExternalReferenceType::LICENSE,
+        ExternalReferenceType::BUILD_META,
+        ExternalReferenceType::BUILD_SYSTEM,
+        ExternalReferenceType::RELEASE_NOTES,
+        ExternalReferenceType::OTHER,
     ];
 
     // @TODO

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -28,6 +28,8 @@ use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
+ * @internal This interface may be affected by breaking changes without notice.
+ *
  * @author jkowalleck
  */
 interface SpecInterface

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -28,7 +28,7 @@ use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
- * @internal This interface may be affected by breaking changes without notice.
+ * @internal as this interface may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -85,6 +86,15 @@ interface SpecInterface
      * version < 1.2 does not support BomRef.
      */
     public function supportsDependencies(): bool;
+
+    /**
+     * @return string[]
+     *
+     * @psalm-return list<ExternalReferenceType::*>
+     */
+    public function getSupportsExternalReferenceTypes(): array;
+
+    public function isSupportsExternalReferenceType(string $referenceType): bool;
 
     /**
      * version < 1.3 does not support hashes in ExternalReference.

--- a/src/Core/Spec/SpecTrait.php
+++ b/src/Core/Spec/SpecTrait.php
@@ -28,7 +28,7 @@ use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
- * @internal
+ * @internal This trait may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Spec/SpecTrait.php
+++ b/src/Core/Spec/SpecTrait.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Spec;
 
 use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
@@ -89,5 +90,20 @@ trait SpecTrait
     public function isSupportedHashContent(string $content): bool
     {
         return 1 === preg_match(self::HASH_CONTENT_REGEX, $content);
+    }
+
+    /**
+     * @return string[]
+     *
+     * @psalm-return list<ExternalReferenceType::*>
+     */
+    public function getSupportsExternalReferenceTypes(): array
+    {
+        return self::EXTERNAL_REFERENCE_TYPES;
+    }
+
+    public function isSupportsExternalReferenceType(string $referenceType): bool
+    {
+        return \in_array($referenceType, self::EXTERNAL_REFERENCE_TYPES, true);
     }
 }

--- a/src/Core/Spec/SpecTrait.php
+++ b/src/Core/Spec/SpecTrait.php
@@ -28,7 +28,7 @@ use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
 /**
- * @internal This trait may be affected by breaking changes without notice.
+ * @internal as this trait may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Spec/Version.php
+++ b/src/Core/Spec/Version.php
@@ -31,4 +31,5 @@ abstract class Version
     public const V_1_1 = '1.1';
     public const V_1_2 = '1.2';
     public const V_1_3 = '1.3';
+    public const V_1_4 = '1.4';
 }

--- a/src/Core/Validation/Errors/JsonValidationError.php
+++ b/src/Core/Validation/Errors/JsonValidationError.php
@@ -32,7 +32,7 @@ use Swaggest\JsonSchema;
 class JsonValidationError extends ValidationError
 {
     /**
-     * @internal This function may be affected by breaking changes without notice.
+     * @internal as this function may be affected by breaking changes without notice
      *
      * @return static
      */

--- a/src/Core/Validation/Errors/JsonValidationError.php
+++ b/src/Core/Validation/Errors/JsonValidationError.php
@@ -32,7 +32,7 @@ use Swaggest\JsonSchema;
 class JsonValidationError extends ValidationError
 {
     /**
-     * @internal
+     * @internal This function may be affected by breaking changes without notice.
      *
      * @return static
      */

--- a/src/Core/Validation/Errors/XmlValidationError.php
+++ b/src/Core/Validation/Errors/XmlValidationError.php
@@ -39,7 +39,7 @@ class XmlValidationError extends ValidationError
     private $debugError;
 
     /**
-     * @internal
+     * @internal This function may be affected by breaking changes without notice.
      *
      * @return static
      */
@@ -54,7 +54,7 @@ class XmlValidationError extends ValidationError
     /**
      * Accessor for debug purposes.
      *
-     * @internal as this method is not kept backwards-compatible
+     * @internal This method may be affected by breaking changes without notice.
      *
      * @codeCoverageIgnore
      *

--- a/src/Core/Validation/Errors/XmlValidationError.php
+++ b/src/Core/Validation/Errors/XmlValidationError.php
@@ -39,7 +39,7 @@ class XmlValidationError extends ValidationError
     private $debugError;
 
     /**
-     * @internal This function may be affected by breaking changes without notice.
+     * @internal as this function may be affected by breaking changes without notice
      *
      * @return static
      */
@@ -54,7 +54,7 @@ class XmlValidationError extends ValidationError
     /**
      * Accessor for debug purposes.
      *
-     * @internal This method may be affected by breaking changes without notice.
+     * @internal as this method may be affected by breaking changes without notice
      *
      * @codeCoverageIgnore
      *

--- a/src/Core/Validation/Helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
+++ b/src/Core/Validation/Helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
@@ -27,7 +27,7 @@ use CycloneDX\Core\Resources;
 use Swaggest\JsonSchema;
 
 /**
- * @internal This class may be affected by breaking changes without notice.
+ * @internal as this class may be affected by breaking changes without notice
  *
  * @author jkowalleck
  */

--- a/src/Core/Validation/Helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
+++ b/src/Core/Validation/Helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
@@ -27,7 +27,7 @@ use CycloneDX\Core\Resources;
 use Swaggest\JsonSchema;
 
 /**
- * @internal
+ * @internal This class may be affected by breaking changes without notice.
  *
  * @author jkowalleck
  */

--- a/src/Core/Validation/ValidationError.php
+++ b/src/Core/Validation/ValidationError.php
@@ -58,7 +58,7 @@ class ValidationError
     }
 
     /**
-     * @internal This function may be affected by breaking changes without notice.
+     * @internal as this function may be affected by breaking changes without notice
      *
      * @return static
      */

--- a/src/Core/Validation/ValidationError.php
+++ b/src/Core/Validation/ValidationError.php
@@ -58,7 +58,7 @@ class ValidationError
     }
 
     /**
-     * @internal
+     * @internal This function may be affected by breaking changes without notice.
      *
      * @return static
      */

--- a/src/Core/Validation/Validators/JsonStrictValidator.php
+++ b/src/Core/Validation/Validators/JsonStrictValidator.php
@@ -42,6 +42,7 @@ class JsonStrictValidator extends JsonValidator
             Version::V_1_1 => null, // unsupported version
             Version::V_1_2 => Resources::FILE_CDX_JSON_STRICT_SCHEMA_1_2,
             Version::V_1_3 => Resources::FILE_CDX_JSON_STRICT_SCHEMA_1_3,
+            Version::V_1_4 => Resources::FILE_CDX_JSON_SCHEMA_1_4, // 1.4 is already strict
         ];
     }
 }

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -50,6 +50,7 @@ class JsonValidator extends BaseValidator
             Version::V_1_1 => null, // unsupported version
             Version::V_1_2 => Resources::FILE_CDX_JSON_SCHEMA_1_2,
             Version::V_1_3 => Resources::FILE_CDX_JSON_SCHEMA_1_3,
+            Version::V_1_4 => Resources::FILE_CDX_JSON_SCHEMA_1_4,
         ];
     }
 

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -42,7 +42,7 @@ class JsonValidator extends BaseValidator
     /**
      * {@inheritdoc}
      *
-     * @internal
+     * @internal This function may be affected by breaking changes without notice.
      */
     protected static function listSchemaFiles(): array
     {

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -42,7 +42,7 @@ class JsonValidator extends BaseValidator
     /**
      * {@inheritdoc}
      *
-     * @internal This function may be affected by breaking changes without notice.
+     * @internal as this function may be affected by breaking changes without notice
      */
     protected static function listSchemaFiles(): array
     {

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -40,7 +40,7 @@ class XmlValidator extends BaseValidator
     /**
      * {@inheritdoc}
      *
-     * @internal This function may be affected by breaking changes without notice.
+     * @internal as this function may be affected by breaking changes without notice
      */
     protected static function listSchemaFiles(): array
     {

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -40,7 +40,7 @@ class XmlValidator extends BaseValidator
     /**
      * {@inheritdoc}
      *
-     * @internal
+     * @internal This function may be affected by breaking changes without notice.
      */
     protected static function listSchemaFiles(): array
     {

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -48,6 +48,7 @@ class XmlValidator extends BaseValidator
             Version::V_1_1 => Resources::FILE_CDX_XML_SCHEMA_1_1,
             Version::V_1_2 => Resources::FILE_CDX_XML_SCHEMA_1_2,
             Version::V_1_3 => Resources::FILE_CDX_XML_SCHEMA_1_3,
+            Version::V_1_4 => Resources::FILE_CDX_XML_SCHEMA_1_4,
         ];
     }
 

--- a/tests/Core/Enums/ClassificationTest.php
+++ b/tests/Core/Enums/ClassificationTest.php
@@ -69,6 +69,7 @@ class ClassificationTest extends TestCase
             BomSpecData::getClassificationEnumForVersion('1.1'),
             BomSpecData::getClassificationEnumForVersion('1.2'),
             BomSpecData::getClassificationEnumForVersion('1.3'),
+            BomSpecData::getClassificationEnumForVersion('1.4'),
         ));
         foreach ($allValues as $value) {
             yield $value => [$value];

--- a/tests/Core/Enums/ExternalReferenceTypeTest.php
+++ b/tests/Core/Enums/ExternalReferenceTypeTest.php
@@ -68,6 +68,7 @@ class ExternalReferenceTypeTest extends TestCase
             BomSpecData::getExternalReferenceTypeForVersion('1.1'),
             BomSpecData::getExternalReferenceTypeForVersion('1.2'),
             BomSpecData::getExternalReferenceTypeForVersion('1.3'),
+            BomSpecData::getExternalReferenceTypeForVersion('1.4'),
         ));
         foreach ($allValues as $value) {
             yield $value => [$value];

--- a/tests/Core/Enums/HashAlgorithmTest.php
+++ b/tests/Core/Enums/HashAlgorithmTest.php
@@ -69,6 +69,7 @@ class HashAlgorithmTest extends TestCase
             BomSpecData::getHashAlgEnumForVersion('1.1'),
             BomSpecData::getHashAlgEnumForVersion('1.2'),
             BomSpecData::getHashAlgEnumForVersion('1.3'),
+            BomSpecData::getHashAlgEnumForVersion('1.4'),
         ));
         foreach ($allValues as $value) {
             yield $value => [$value];

--- a/tests/Core/Serialize/JsonSerializerTest.php
+++ b/tests/Core/Serialize/JsonSerializerTest.php
@@ -106,4 +106,40 @@ class JsonSerializerTest extends TestCase
             $actual
         );
     }
+
+    /**
+     * @uses   \CycloneDX\Core\Serialize\JSON\AbstractNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\NormalizerFactory
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\BomNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\ComponentRepositoryNormalizer
+     * @uses   \CycloneDX\Core\Serialize\JSON\Normalizers\ComponentNormalizer
+     * @uses   \CycloneDX\Core\Serialize\BomRefDiscriminator
+     */
+    public function testSerialize14(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.4',
+                'isSupportedFormat' => true,
+            ]
+        );
+        $serializer = new JsonSerializer($spec);
+        $bom = $this->createStub(Bom::class);
+
+        $actual = $serializer->serialize($bom);
+
+        self::assertJsonStringEqualsJsonString(
+            <<<'JSON'
+                {
+                    "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+                    "bomFormat": "CycloneDX",
+                    "specVersion": "1.4",
+                    "version": 0,
+                    "components": []
+                }
+                JSON,
+            $actual
+        );
+    }
 }

--- a/tests/Core/Serialize/XmlSerializerTest.php
+++ b/tests/Core/Serialize/XmlSerializerTest.php
@@ -133,4 +133,37 @@ class XmlSerializerTest extends TestCase
             $actual
         );
     }
+
+    /**
+     * @uses   \CycloneDX\Core\Serialize\DOM\AbstractNormalizer
+     * @uses   \CycloneDX\Core\Serialize\DOM\NormalizerFactory
+     * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\BomNormalizer
+     * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\ComponentRepositoryNormalizer
+     * @uses   \CycloneDX\Core\Serialize\DOM\Normalizers\ComponentNormalizer
+     * @uses   \CycloneDX\Core\Serialize\BomRefDiscriminator
+     */
+    public function testSerialize14(): void
+    {
+        $spec = $this->createConfiguredMock(
+            SpecInterface::class,
+            [
+                'getVersion' => '1.4',
+                'isSupportedFormat' => true,
+            ]
+        );
+        $serializer = new XmlSerializer($spec);
+        $bom = $this->createStub(Bom::class);
+
+        $actual = $serializer->serialize($bom);
+
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="0">
+                  <components/>
+                </bom>
+                XML,
+            $actual
+        );
+    }
 }

--- a/tests/Core/SerializeToJsonTest.php
+++ b/tests/Core/SerializeToJsonTest.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Serialize\JsonSerializer;
 use CycloneDX\Core\Spec\Spec11;
 use CycloneDX\Core\Spec\Spec12;
 use CycloneDX\Core\Spec\Spec13;
+use CycloneDX\Core\Spec\Spec14;
 use CycloneDX\Core\Validation\Validators\JsonStrictValidator;
 use DomainException;
 use PHPUnit\Framework\TestCase;
@@ -108,4 +109,29 @@ class SerializeToJsonTest extends TestCase
     }
 
     // endregion Spec 1.3
+
+    // region Spec 1.4
+
+    /**
+     * This test might be slow.
+     * This test might require online-connectivity.
+     *
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
+     */
+    public function testSchema14(Bom $bom): void
+    {
+        $spec = new Spec14();
+        $serializer = new JsonSerializer($spec);
+        $validator = new JsonStrictValidator($spec);
+
+        $json = $serializer->serialize($bom);
+        self::assertJson($json);
+
+        $validationErrors = $validator->validateString($json);
+        self::assertNull($validationErrors);
+    }
+
+    // endregion Spec 1.4
 }

--- a/tests/Core/SerializeToXmlTest.php
+++ b/tests/Core/SerializeToXmlTest.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Serialize\XmlSerializer;
 use CycloneDX\Core\Spec\Spec11;
 use CycloneDX\Core\Spec\Spec12;
 use CycloneDX\Core\Spec\Spec13;
+use CycloneDX\Core\Spec\Spec14;
 use CycloneDX\Core\Validation\Validators\XmlValidator;
 use PHPUnit\Framework\TestCase;
 
@@ -111,4 +112,28 @@ class SerializeToXmlTest extends TestCase
     }
 
     // endregion Spec 1.3
+
+    // region Spec 1.4
+
+    /**
+     * This test might be slow.
+     * This test might require online-connectivity.
+     *
+     * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
+     *
+     * @throws \Exception on validation failure
+     */
+    public function testSchema14(Bom $bom): void
+    {
+        $spec = new Spec14();
+        $serializer = new XmlSerializer($spec);
+        $validator = new XmlValidator($spec);
+
+        $xml = $serializer->serialize($bom);
+        $validationErrors = $validator->validateString($xml);
+
+        self::assertNull($validationErrors);
+    }
+
+    // endregion Spec 1.4
 }

--- a/tests/Core/Spec/Spec14Test.php
+++ b/tests/Core/Spec/Spec14Test.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Spec;
 
 use CycloneDX\Core\Spec\Format;
+use CycloneDX\Core\Spec\Spec14;
 use CycloneDX\Core\Spec\SpecInterface;
 
 /**

--- a/tests/Core/Spec/Spec14Test.php
+++ b/tests/Core/Spec/Spec14Test.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of CycloneDX PHP Library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+namespace CycloneDX\Tests\Core\Spec;
+
+use CycloneDX\Core\Spec\Format;
+use CycloneDX\Core\Spec\SpecInterface;
+
+/**
+ * @covers \CycloneDX\Core\Spec\Spec14
+ */
+class Spec14Test extends AbstractSpecTestCase
+{
+    protected function getSpec(): SpecInterface
+    {
+        return new Spec14();
+    }
+
+    protected function getSpecVersion(): string
+    {
+        return '1.4';
+    }
+
+    protected function shouldSupportFormats(): array
+    {
+        return [Format::XML, Format::JSON];
+    }
+
+    public function shouldSupportLicenseExpression(): bool
+    {
+        return true;
+    }
+
+    public function shouldSupportMetaData(): bool
+    {
+        return true;
+    }
+
+    public function shouldSupportBomRef(): bool
+    {
+        return true;
+    }
+
+    public function shouldSupportDependencies(): bool
+    {
+        return true;
+    }
+
+    public function shouldSupportExternalReferenceHashes(): bool
+    {
+        return true;
+    }
+}

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -195,7 +195,8 @@ abstract class BomModelProvider
             ...BomSpecData::getClassificationEnumForVersion('1.0'),
             ...BomSpecData::getClassificationEnumForVersion('1.1'),
             ...BomSpecData::getClassificationEnumForVersion('1.2'),
-            ...BomSpecData::getClassificationEnumForVersion('1.3')
+            ...BomSpecData::getClassificationEnumForVersion('1.3'),
+            ...BomSpecData::getClassificationEnumForVersion('1.4')
         );
     }
 
@@ -257,6 +258,14 @@ abstract class BomModelProvider
     public static function bomWithComponentTypeSpec13(): Generator
     {
         yield from self::bomWithComponentTypes(...BomSpecData::getClassificationEnumForVersion('1.3'));
+    }
+
+    /**
+     * @psalm-return Generator<array{0: Bom}>
+     */
+    public static function bomWithComponentTypeSpec14(): Generator
+    {
+        yield from self::bomWithComponentTypes(...BomSpecData::getClassificationEnumForVersion('1.4'));
     }
 
     /**
@@ -391,7 +400,8 @@ abstract class BomModelProvider
                     BomSpecData::getHashAlgEnumForVersion('1.0'),
                     BomSpecData::getHashAlgEnumForVersion('1.1'),
                     BomSpecData::getHashAlgEnumForVersion('1.2'),
-                    BomSpecData::getHashAlgEnumForVersion('1.3')
+                    BomSpecData::getHashAlgEnumForVersion('1.3'),
+                    BomSpecData::getHashAlgEnumForVersion('1.4')
                 ),
                 \SORT_STRING
             )
@@ -448,6 +458,16 @@ abstract class BomModelProvider
     public static function bomWithComponentHashAlgorithmsSpec13(): Generator
     {
         yield from self::bomWithComponentHashAlgorithms(...BomSpecData::getHashAlgEnumForVersion('1.3'));
+    }
+
+    /**
+     * BOMs with all hash algorithms available in Spec 1.4.
+     *
+     * @psalm-return Generator<array{0: Bom}>
+     */
+    public static function bomWithComponentHashAlgorithmsSpec14(): Generator
+    {
+        yield from self::bomWithComponentHashAlgorithms(...BomSpecData::getHashAlgEnumForVersion('1.4'));
     }
 
     /**
@@ -601,6 +621,7 @@ abstract class BomModelProvider
                 BomSpecData::getExternalReferenceTypeForVersion('1.1'),
                 BomSpecData::getExternalReferenceTypeForVersion('1.2'),
                 BomSpecData::getExternalReferenceTypeForVersion('1.3'),
+                BomSpecData::getExternalReferenceTypeForVersion('1.4'),
             )
         );
 

--- a/tools/schema-downloader/download.php
+++ b/tools/schema-downloader/download.php
@@ -37,7 +37,7 @@ const TARGET_ROOT = __DIR__.'/../../res/';
 
 abstract class BomXsd
 {
-    public const Versions = ['1.0', '1.1', '1.2', '1.3'];
+    public const Versions = ['1.0', '1.1', '1.2', '1.3', '1.4'];
     public const SourcePattern = SOURCE_ROOT.'bom-%s.xsd';
     public const TargetPattern = TARGET_ROOT.'bom-%s.SNAPSHOT.xsd';
     public const Replace = [
@@ -48,23 +48,27 @@ abstract class BomXsd
 
 abstract class BomJsonLax
 {
-    public const Versions = ['1.2', '1.3'];
+    public const Versions = ['1.2', '1.3', '1.4'];
     public const SourcePattern = SOURCE_ROOT.'bom-%s.schema.json';
     public const TargetPattern = TARGET_ROOT.'bom-%s.SNAPSHOT.schema.json';
     public const Replace = [
         'spdx.schema.json' => 'spdx.SNAPSHOT.schema.json',
+        'jsf-0.82.schema.json' => 'jsf-0.82.SNAPSHOT.schema.json',
     ];
 }
 
-abstract class BomJsonStrict extends BomJsonLax
+abstract class BomJsonStrict
 {
+    public const Versions = ['1.2', '1.3'];
     public const SourcePattern = SOURCE_ROOT.'bom-%s-strict.schema.json';
     public const TargetPattern = TARGET_ROOT.'bom-%s-strict.SNAPSHOT.schema.json';
+    public const Replace = BomJsonLax::Replace;
 }
 
 const Others = [
     SOURCE_ROOT.'spdx.schema.json' => TARGET_ROOT.'spdx.SNAPSHOT.schema.json',
     SOURCE_ROOT.'spdx.xsd' => TARGET_ROOT.'spdx.SNAPSHOT.xsd',
+    SOURCE_ROOT.'jsf-0.82.schema.json' => TARGET_ROOT.'jsf-0.82.SNAPSHOT.schema.json',
 ];
 
 foreach ([


### PR DESCRIPTION

* BREAKING changes
  * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
    This is done to prevent the need for future "breaking changed" when the schema requires additional spec implementations.
* Changed
  * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
    This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
* Added
  * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` for CycloneDX v1.4. (via [#65])
  * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
  * Support for CycloneDX v1.4 in `CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
  * New methods in class `\CycloneDX\Core\Spec\Spec1{1,2,3}` (via [#65])
    * `::getSupportsExternalReferenceTypes()`
    * `::isSupportsExternalReferenceType()`
  * New class constant `CycloneDX\Core\Enums\ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4. (via [#65])


----

from milestone tasks:

- [x] Add spec 1.4 schemas to `schemas` folder
- [x] Add JSF schemas to `schemas` folder - used in draft 1.4 as a reference
- [x] Add spec 1.4 schema validation

---- 