### PR TITLE
fix psalm doc of `SerializerInterface::serialize()`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * Return type of `CycloneDX\Core\Serialize\SerializerInterface::serialize()` and implementations/usage
+    are documented as `non-empty-string`, were undocumented `string` before. (via [#70])
+
+[#70]: https://github.com/CycloneDX/cyclonedx-php-library/pull/70
+
 ## 1.4.1 - 2022-01-31
 
 * Fixed

--- a/src/Core/Serialize/BaseSerializer.php
+++ b/src/Core/Serialize/BaseSerializer.php
@@ -77,7 +77,9 @@ abstract class BaseSerializer implements SerializerInterface
     /**
      * Normalize the Bom to a string.
      *
-     *  May throw implementation-dependent Exceptions.
+     * May throw implementation-dependent Exceptions.
+     *
+     * @psalm-return non-empty-string
      */
     abstract protected function normalize(Bom $bom): string;
 

--- a/src/Core/Serialize/JsonSerializer.php
+++ b/src/Core/Serialize/JsonSerializer.php
@@ -73,6 +73,7 @@ class JsonSerializer extends BaseSerializer
 
         $json = json_encode(array_merge($schemaBase, $data), self::NORMALIZE_OPTIONS);
         \assert(false !== $json); // as option JSON_THROW_ON_ERROR is expected to be set
+        \assert('' !== $json);
 
         return $json;
     }

--- a/src/Core/Serialize/SerializerInterface.php
+++ b/src/Core/Serialize/SerializerInterface.php
@@ -34,6 +34,8 @@ interface SerializerInterface
      * Serialize a {@see \CycloneDX\Core\Models\Bom} to string.
      *
      * May throw implementation-dependent Exceptions.
+     *
+     * @psalm-return non-empty-string
      */
     public function serialize(Bom $bom): string;
 }

--- a/src/Core/Serialize/XmlSerializer.php
+++ b/src/Core/Serialize/XmlSerializer.php
@@ -60,6 +60,7 @@ class XmlSerializer extends BaseSerializer
         // option LIBXML_NOEMPTYTAG might lead to errors in consumers
         $xml = $document->saveXML();
         \assert(false !== $xml);
+        \assert('' !== $xml);
 
         return $xml;
     }


### PR DESCRIPTION
Fix:
Return type of `CycloneDX\Core\Serialize\SerializerInterface::serialize()` and implementations/usage
are documented as `non-empty-string`, were undocumented `string` before.
