### PR TITLE
make dev-tools php requirement clear

### DIFF
--- a/tools/composer-normalize/composer.json
+++ b/tools/composer-normalize/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-normalize",
     "description": "composer-normalize",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "ergebnis/composer-normalize": "2.23.1",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-require-checker/composer.json
+++ b/tools/composer-require-checker/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-require-checker",
     "description": "composer-require-checker",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "maglnet/composer-require-checker": "3.8.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/composer-unused/composer.json
+++ b/tools/composer-unused/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/composer-unused",
     "description": "composer-unused",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "composer/composer": "^2.1.12",
         "icanhazstring/composer-unused": "0.7.12",

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/php-cs-fixer",
     "description": "php-cs-fixer",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.6.0",
         "roave/security-advisories": "dev-latest"

--- a/tools/phpmd/composer.json
+++ b/tools/phpmd/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/phpmd",
     "description": "phpmd",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "phpmd/phpmd": "2.11.1",
         "roave/security-advisories": "dev-latest"

--- a/tools/psalm/composer.json
+++ b/tools/psalm/composer.json
@@ -2,6 +2,9 @@
     "name": "tools/psalm",
     "description": "psalm and plugins",
     "type": "metapackage",
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "vimeo/psalm": "4.20.0"


### PR DESCRIPTION
the `CONTRIBUTING.md` file states 
```md
The development-setup requires PHP >= 7.4,
even though the project might support PHP 7.3 on runtime.
```

to make the constraint clear, all tools's composer manifests were fixed to that fact