### PR TITLE
ComponentVersion became optional

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,16 +12,19 @@ All notable changes to this project will be documented in this file.
 * Changed
   * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
     This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
+  * Class `\CycloneDX\Core\Models\Component`'s property `version` is optional now, to reflect CycloneDX v1.4. (via [#118])  
+    This affects constructor arguments, and affects methods `{get,set}Version()`.
 * Added
   * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` for CycloneDX v1.4. (via [#65])
   * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
-  * Support for CycloneDX v1.4 in `CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
+  * Support for CycloneDX v1.4 in `\CycloneDX\Core\Validation\Validators\{Json,Xml}StrictValidator`. (via [#65])
   * New methods in class `\CycloneDX\Core\Spec\Spec1{1,2,3}` (via [#65])
     * `::getSupportsExternalReferenceTypes()`
     * `::isSupportsExternalReferenceType()`
   * New class constant `CycloneDX\Core\Enums\ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4. (via [#65])
 
 [#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
+[#118]: https://github.com/CycloneDX/cyclonedx-php-library/pull/118
 
 ## 1.6.2 - 2022-09-12
 

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -138,9 +138,7 @@ class Component
      * The component version. The version should ideally comply with semantic versioning
      * but is not enforced.
      *
-     * @var string
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
+     * @var string|null
      */
     private $version;
 
@@ -303,7 +301,7 @@ class Component
         return $this;
     }
 
-    public function getVersion(): string
+    public function getVersion(): ?string
     {
         return $this->version;
     }
@@ -311,7 +309,7 @@ class Component
     /**
      * @return $this
      */
-    public function setVersion(string $version): self
+    public function setVersion(?string $version): self
     {
         $this->version = $version;
 
@@ -368,7 +366,7 @@ class Component
      *
      * @throws DomainException if type is unknown
      */
-    public function __construct(string $type, string $name, string $version)
+    public function __construct(string $type, string $name, ?string $version = null)
     {
         $this->setType($type);
         $this->setName($name);

--- a/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
@@ -58,7 +58,10 @@ class ComponentNormalizer extends AbstractNormalizer
 
         $type = $component->getType();
         if (false === $spec->isSupportedComponentType($type)) {
-            $reportFQN = "$group/$name@$version";
+            $reportFQN = "$group/$name";
+            if (null !== $version) {
+                $reportFQN .= "@$version";
+            }
             throw new DomainException("Component '$reportFQN' has unsupported type: $type");
         }
 
@@ -80,7 +83,11 @@ class ComponentNormalizer extends AbstractNormalizer
                 // publisher
                 $this->simpleDomSafeTextElement($document, 'group', $group),
                 $this->simpleDomSafeTextElement($document, 'name', $name),
-                $this->simpleDomSafeTextElement($document, 'version', $version),
+                $this->simpleDomSafeTextElement($document, 'version',
+                    null === $version && $spec->requiresComponentVersion()
+                        ? ''
+                        : $version
+                ),
                 $this->simpleDomSafeTextElement($document, 'description', $component->getDescription()),
                 // scope
                 $this->normalizeHashes($component->getHashRepository()),

--- a/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
@@ -54,7 +54,10 @@ class ComponentNormalizer extends AbstractNormalizer
 
         $type = $component->getType();
         if (false === $spec->isSupportedComponentType($type)) {
-            $reportFQN = "$group/$name@$version";
+            $reportFQN = "$group/$name";
+            if (null !== $version) {
+                $reportFQN .= "@$version";
+            }
             throw new DomainException("Component '$reportFQN' has unsupported type: $type");
         }
 
@@ -67,7 +70,9 @@ class ComponentNormalizer extends AbstractNormalizer
                 'bom-ref' => $bomRef,
                 'type' => $type,
                 'name' => $name,
-                'version' => $version,
+                'version' => null === $version && $spec->requiresComponentVersion()
+                    ? ''
+                    : $version,
                 'group' => $group,
                 'description' => $component->getDescription(),
                 'licenses' => $this->normalizeLicense($component->getLicense()),

--- a/src/Core/Spec/Spec11.php
+++ b/src/Core/Spec/Spec11.php
@@ -103,4 +103,9 @@ final class Spec11 implements SpecInterface
     {
         return false;
     }
+
+    public function requiresComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/Spec12.php
+++ b/src/Core/Spec/Spec12.php
@@ -111,4 +111,9 @@ final class Spec12 implements SpecInterface
     {
         return false;
     }
+
+    public function requiresComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/Spec13.php
+++ b/src/Core/Spec/Spec13.php
@@ -111,4 +111,9 @@ final class Spec13 implements SpecInterface
     {
         return true;
     }
+
+    public function requiresComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/src/Core/Spec/Spec14.php
+++ b/src/Core/Spec/Spec14.php
@@ -115,4 +115,9 @@ final class Spec14 implements SpecInterface
     {
         return true;
     }
+
+    public function requiresComponentVersion(): bool
+    {
+        return false;
+    }
 }

--- a/src/Core/Spec/SpecInterface.php
+++ b/src/Core/Spec/SpecInterface.php
@@ -102,4 +102,9 @@ interface SpecInterface
      * version < 1.3 does not support hashes in ExternalReference.
      */
     public function supportsExternalReferenceHashes(): bool;
+
+    /**
+     * version < 1.4 requires components to have a version, later it became optional.
+     */
+    public function requiresComponentVersion(): bool;
 }

--- a/tests/Core/Spec/AbstractSpecTestCase.php
+++ b/tests/Core/Spec/AbstractSpecTestCase.php
@@ -197,4 +197,12 @@ abstract class AbstractSpecTestCase extends TestCase
     }
 
     abstract public function shouldSupportExternalReferenceHashes(): bool;
+
+    final public function testRequiresComponentVersion(): void
+    {
+        $isSupported = $this->getSpec()->requiresComponentVersion();
+        self::assertSame($this->shouldRequireComponentVersion(), $isSupported);
+    }
+
+    abstract public function shouldRequireComponentVersion(): bool;
 }

--- a/tests/Core/Spec/Spec11Test.php
+++ b/tests/Core/Spec/Spec11Test.php
@@ -71,4 +71,9 @@ class Spec11Test extends AbstractSpecTestCase
     {
         return false;
     }
+
+    public function shouldRequireComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Core/Spec/Spec12Test.php
+++ b/tests/Core/Spec/Spec12Test.php
@@ -71,4 +71,9 @@ class Spec12Test extends AbstractSpecTestCase
     {
         return false;
     }
+
+    public function shouldRequireComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Core/Spec/Spec13Test.php
+++ b/tests/Core/Spec/Spec13Test.php
@@ -71,4 +71,9 @@ class Spec13Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldRequireComponentVersion(): bool
+    {
+        return true;
+    }
 }

--- a/tests/Core/Spec/Spec14Test.php
+++ b/tests/Core/Spec/Spec14Test.php
@@ -71,4 +71,9 @@ class Spec14Test extends AbstractSpecTestCase
     {
         return true;
     }
+
+    public function shouldRequireComponentVersion(): bool
+    {
+        return false;
+    }
 }

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -175,7 +175,7 @@ abstract class BomModelProvider
         yield 'component: plain' => [
             (new Bom())->setComponentRepository(
                 new ComponentRepository(
-                    new Component(Classification::LIBRARY, 'name', 'version')
+                    new Component(Classification::LIBRARY, 'name')
                 )
             ),
         ];


### PR DESCRIPTION
fixes #27 

as of spec 1.4 the Component's version is optional.

all methods stayed backwards compatible.