### PR TITLE
breaking: drop support for php v7.3 and v7.4

### DIFF
--- a/.github/workflows/php-dev.yml
+++ b/.github/workflows/php-dev.yml
@@ -36,10 +36,7 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         php:
           - "8.1" # highest supported
-          - "8.0"
-          - "7.4"
-          ## below is a list of versions the project supports on runtime - but not on dev-time
-          # - "7.3" # lowest supported
+          - "8.0" # lowest supported
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,9 +29,7 @@ jobs:
         os: [ "ubuntu-latest" ]
         php:
           - "8.1" # highest supported
-          - "8.0"
-          - "7.4"
-          - "7.3" # lowest supported
+          - "8.0" # lowest supported
         dependencies: [ "lowest", "highest" ]
         exclude:
           - # unstable combinations: `Swaggest\JsonSchema` on php8.1 - throws PHP Deprecated warnings
@@ -120,7 +118,7 @@ jobs:
             php: "8.1"
             dependencies: "highest"
           - # lowest supported
-            php: "7.3"
+            php: "8.0"
             dependencies: "lowest"
     steps:
       - name: Checkout

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -162,6 +162,7 @@ jobs:
           --no-diff
           --no-cache
           --long-progress
+          --output-format=github
           --report=${{ env.REPORTS_DIR }}/psalm.php${{ matrix.php }}_${{ matrix.dependencies }}.junit.xml
       - name: Artifact reports
         if: ${{ ! cancelled() }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,11 +30,11 @@ $finder = PhpCsFixer\Finder::create()
 return (new PhpCsFixer\Config())
     ->setUsingCache(true)
     ->setRules(
-    // docs: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/doc/rules/index.rst
+    // docs: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/index.rst
     // assistance via tool: https://mlocati.github.io/php-cs-fixer-configurator/
         [
-            '@PHP71Migration:risky' => true,
-            '@PHP73Migration' => true,
+            '@PHP80Migration' => true,
+            '@PHP80Migration:risky' => true,
             '@Symfony' => true,
             '@Symfony:risky' => true,
             'declare_strict_types' => true,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   * Dropped support for php v7.3 and v7.4. (via [#125])
   * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
     This is done to prevent the need for future "breaking changed" when the schema requires additional spec implementations.
+  * API changes:
+    * ... TO LOST 
 * Changed
   * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
     This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,13 +10,20 @@ All notable changes to this project will be documented in this file.
   * Dropped support for php v7.3 and v7.4. (via [#125])
   * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
     This is done to prevent the need for future "breaking changed" when the schema requires additional spec implementations.
-  * API changes:
-    * ... TO LOST 
+  * API
+    * Some methods now enforce the use of concrete union types instead of protocols.  (via [#125])
+      Affected the usages of `\CycloneDX\Core\Models\License\AbstractDisjunctiveLicense` and methods that used license-related classes.
+      This was possible due to php8's UnionType language feature.
 * Changed
   * Method `\CycloneDX\Core\Serialize\{DOM,JSON}\Normalizers\ExternalReferenceNormalizer::normalize` throw `DomainException` when `ExternalReference`'s type was not supported by the spec.  (via [#65])  
     This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
   * Class `\CycloneDX\Core\Models\Component`'s property `version` is optional now, to reflect CycloneDX v1.4. (via [#118])  
     This affects constructor arguments, and affects methods `{get,set}Version()`.
+  * Some methods no longer throw `InvalidArgumentException`. (via [#125])  
+    This was possible by enforcing correct typing on language level.
+* Removed
+  * The public usage of the internal class `\CycloneDX\Core\Models\License\AbstractDisjunctiveLicense`. (via [#125])  
+    This was possible due php8's UnionType language feature.
 * Added
   * New class constant `\CycloneDX\Core\Spec\Version::V_1_4` for CycloneDX v1.4. (via [#65])
   * New class `\CycloneDX\Core\Spec\Spec14` to reflect CycloneDX v1.4. (via [#65])
@@ -26,6 +33,11 @@ All notable changes to this project will be documented in this file.
     * `::isSupportedExternalReferenceType()` (via [#65], [#124])
     * `::supportsToolExternalReferences()` (via [#123])
   * New class constant `CycloneDX\Core\Enums\ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4. (via [#65])
+* Style
+  * All class properties now enforce the correct types. (via [#125])  
+    This is considered a non-breaking change, because the types were already correctly annotated.  
+    This was possible due to php74's features and php8's UnionType language feature.
+  * Migrated internals to php8 language features. (via [#125])
 
 [#65]: https://github.com/CycloneDX/cyclonedx-php-library/pull/65
 [#118]: https://github.com/CycloneDX/cyclonedx-php-library/pull/118

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## 2.0.0 - unreleased
 
 * BREAKING changes
+  * Dropped support for php v7.3 and v7.4. (via [#125])
   * Interface `\CycloneDX\Core\Spec\SpecInterface` became internal, was public api. (via [#65])  
     This is done to prevent the need for future "breaking changed" when the schema requires additional spec implementations.
 * Changed
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#118]: https://github.com/CycloneDX/cyclonedx-php-library/pull/118
 [#123]: https://github.com/CycloneDX/cyclonedx-php-library/pull/123
 [#124]: https://github.com/CycloneDX/cyclonedx-php-library/pull/123
+[#125]: https://github.com/CycloneDX/cyclonedx-php-library/pull/125
 
 ## 1.6.3 - 2022-09-15
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "source": "https://github.com/CycloneDX/cyclonedx-php-library/"
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",

--- a/src/Core/Factories/LicenseFactory.php
+++ b/src/Core/Factories/LicenseFactory.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Factories;
 
-use CycloneDX\Core\Models\License\AbstractDisjunctiveLicense;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
@@ -34,10 +33,7 @@ use UnexpectedValueException;
 
 class LicenseFactory
 {
-    /**
-     * @var SpdxLicenseValidator|null
-     */
-    private $spdxLicenseValidator;
+    private ?SpdxLicenseValidator $spdxLicenseValidator;
 
     public function __construct(?SpdxLicenseValidator $spdxLicenseValidator = null)
     {
@@ -66,14 +62,11 @@ class LicenseFactory
         return $this;
     }
 
-    /**
-     * @return DisjunctiveLicenseWithName|DisjunctiveLicenseWithId|LicenseExpression
-     */
-    public function makeFromString(string $license)
+    public function makeFromString(string $license): DisjunctiveLicenseWithName|DisjunctiveLicenseWithId|LicenseExpression
     {
         try {
             return $this->makeExpression($license);
-        } catch (DomainException $exception) {
+        } catch (DomainException) {
             return $this->makeDisjunctive($license);
         }
     }
@@ -86,14 +79,11 @@ class LicenseFactory
         return new LicenseExpression($license);
     }
 
-    /**
-     * @return DisjunctiveLicenseWithId|DisjunctiveLicenseWithName
-     */
-    public function makeDisjunctive(string $license): AbstractDisjunctiveLicense
+    public function makeDisjunctive(string $license): DisjunctiveLicenseWithId|DisjunctiveLicenseWithName
     {
         try {
             return $this->makeDisjunctiveWithId($license);
-        } catch (UnexpectedValueException|DomainException $exception) {
+        } catch (UnexpectedValueException|DomainException) {
             return $this->makeDisjunctiveWithName($license);
         }
     }

--- a/src/Core/Factories/LicenseFactory.php
+++ b/src/Core/Factories/LicenseFactory.php
@@ -47,12 +47,8 @@ class LicenseFactory
      */
     public function getSpdxLicenseValidator(): SpdxLicenseValidator
     {
-        $validator = $this->spdxLicenseValidator;
-        if (null === $validator) {
-            throw new UnexpectedValueException('Missing spdxLicenseValidator');
-        }
-
-        return $validator;
+        return $this->spdxLicenseValidator
+            ?? throw new UnexpectedValueException('Missing spdxLicenseValidator');
     }
 
     public function setSpdxLicenseValidator(SpdxLicenseValidator $spdxLicenseValidator): self

--- a/src/Core/Helpers/NullAssertionTrait.php
+++ b/src/Core/Helpers/NullAssertionTrait.php
@@ -31,11 +31,9 @@ namespace CycloneDX\Core\Helpers;
 trait NullAssertionTrait
 {
     /**
-     * @param mixed|null $value
-     *
      * @psalm-assert-if-true !null $value
      */
-    private function isNotNull($value): bool
+    private function isNotNull(mixed $value): bool
     {
         return null !== $value;
     }

--- a/src/Core/Helpers/SimpleDomTrait.php
+++ b/src/Core/Helpers/SimpleDomTrait.php
@@ -65,12 +65,11 @@ trait SimpleDomTrait
     }
 
     /**
-     * @param mixed|null $data
-     * @param bool       $null whether to return null when `$data` is null
+     * @param bool $null whether to return null when `$data` is null
      *
      * @return DOMElement|null ($null is true && $data is null ? null : DOMElement)
      */
-    private function simpleDomSafeTextElement(DOMDocument $document, string $name, $data, bool $null = true): ?DOMElement
+    private function simpleDomSafeTextElement(DOMDocument $document, string $name, mixed $data, bool $null = true): ?DOMElement
     {
         $element = $document->createElement($name);
         if (null !== $data) {

--- a/src/Core/Models/Bom.php
+++ b/src/Core/Models/Bom.php
@@ -98,10 +98,9 @@ class Bom
      */
     public function setVersion(int $version): self
     {
-        if (false === $this->isValidVersion($version)) {
-            throw new DomainException("Invalid value: $version");
-        }
-        $this->version = $version;
+        $this->version = $this->isValidVersion($version)
+            ? $version
+            : throw new DomainException("Invalid value: $version");
 
         return $this;
     }

--- a/src/Core/Models/Bom.php
+++ b/src/Core/Models/Bom.php
@@ -34,11 +34,9 @@ use DomainException;
 class Bom
 {
     /**
-     * @var ComponentRepository
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $componentRepository;
+    private ComponentRepository $componentRepository;
 
     /**
      * The version allows component publishers/authors to make changes to existing BOMs to update various aspects of the document such as description or licenses.
@@ -46,26 +44,20 @@ class Bom
      * The default version is '1' and should be incremented for each version of the BOM that is published.
      * Each version of a component should have a unique BOM and if no changes are made to the BOMs, then each BOM will have a version of '1'.
      *
-     * @var int
-     *
      * @psalm-var positive-int
      */
-    private $version = 1;
+    private int $version = 1;
 
     /**
-     * @var MetaData|null
-     *
      * @TODO deprecated rename it in v4 to `$metadata` and also rename the getter/setter
      */
-    private $metaData;
+    private ?MetaData $metaData = null;
 
     /**
      * Provides the ability to document external references related to the BOM or
      * to the project the BOM describes.
-     *
-     * @var ExternalReferenceRepository|null
      */
-    private $externalReferenceRepository;
+    private ?ExternalReferenceRepository $externalReferenceRepository = null;
 
     public function __construct(?ComponentRepository $componentRepository = null)
     {

--- a/src/Core/Models/BomRef.php
+++ b/src/Core/Models/BomRef.php
@@ -35,10 +35,7 @@ namespace CycloneDX\Core\Models;
  */
 final class BomRef
 {
-    /**
-     * @var string|null
-     */
-    private $value;
+    private ?string $value;
 
     public function __construct(?string $value = null)
     {

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -31,7 +31,6 @@ use CycloneDX\Core\Repositories\ExternalReferenceRepository;
 use CycloneDX\Core\Repositories\HashRepository;
 use DomainException;
 use PackageUrl\PackageUrl;
-use UnexpectedValueException;
 
 /**
  * @author nscuro
@@ -44,10 +43,8 @@ class Component
      *
      * Implementation is intended to prevent memory leaks.
      * See ../../../docs/dev/decisions/BomDependencyDataModel.md
-     *
-     * @var BomRef
      */
-    private $bomRef;
+    private BomRef $bomRef;
 
     /**
      * The name of the component. This will often be a shortened, single name
@@ -55,11 +52,9 @@ class Component
      *
      * Examples: commons-lang3 and jquery
      *
-     * @var string
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $name;
+    private string $name;
 
     /**
      * The grouping name or identifier. This will often be a shortened, single
@@ -69,11 +64,9 @@ class Component
      *
      * Examples include: apache, org.apache.commons, and apache.org.
      *
-     * @var string|null
-     *
      * @psalm-var non-empty-string|null
      */
-    private $group;
+    private ?string $group = null;
 
     /**
      * Specifies the type of component. For software components, classify as application if no more
@@ -83,72 +76,56 @@ class Component
      * Refer to the {@link https://cyclonedx.org/schema/bom/1.1 bom:classification documentation}
      * for information describing each one.
      *
-     * @var string
-     *
      * @psalm-var Classification::*
      *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $type;
+    private string $type;
 
     /**
      * Specifies a description for the component.
      *
-     * @var string|null
-     *
      * @psalm-var non-empty-string|null
      */
-    private $description;
+    private ?string $description = null;
 
     /**
      * Package-URL (PURL).
      *
      * The purl, if specified, must be valid and conform to the specification
      * defined at: {@linnk https://github.com/package-url/purl-spec/blob/master/README.rst#purl}.
-     *
-     * @var PackageUrl|null
      */
-    private $packageUrl;
+    private ?PackageUrl $packageUrl = null;
 
     /**
      * licence(s).
-     *
-     * @var LicenseExpression|DisjunctiveLicenseRepository|null
      */
-    private $license;
+    private LicenseExpression|DisjunctiveLicenseRepository|null $license = null;
 
     /**
      * Specifies the file hashes of the component.
-     *
-     * @var HashRepository|null
      */
-    private $hashRepository;
+    private ?HashRepository $hashRepository = null;
 
     /**
      * References to dependencies.
      *
      * Implementation is intended to prevent memory leaks.
      * See ../../../docs/dev/decisions/BomDependencyDataModel.md
-     *
-     * @var BomRefRepository|null
      */
-    private $dependenciesBomRefRepository;
+    private ?BomRefRepository $dependenciesBomRefRepository = null;
 
     /**
      * The component version. The version should ideally comply with semantic versioning
      * but is not enforced.
-     *
-     * @var string|null
      */
-    private $version;
+    private ?string $version = null;
 
     /**
      * Provides the ability to document external references related to the
      * component or to the project the component describes.
-     *
-     * @var ExternalReferenceRepository|null
      */
-    private $externalReferenceRepository;
+    private ?ExternalReferenceRepository $externalReferenceRepository = null;
 
     public function getBomRef(): BomRef
     {
@@ -246,44 +223,19 @@ class Component
         return $this;
     }
 
-    /**
-     * @return LicenseExpression|DisjunctiveLicenseRepository|null
-     */
-    public function getLicense()
+    public function getLicense(): LicenseExpression|DisjunctiveLicenseRepository|null
     {
         return $this->license;
     }
 
-    /**
-     * @param mixed $license
-     *
-     * @psalm-assert LicenseExpression|DisjunctiveLicenseRepository|null $license
-     *
-     * @throws UnexpectedValueException
-     *
+    /***
      * @return $this
      */
-    public function setLicense($license): self
+    public function setLicense(LicenseExpression|DisjunctiveLicenseRepository|null $license): self
     {
-        if (false === $this->isValidLicense($license)) {
-            throw new UnexpectedValueException('Invalid license type');
-        }
-
         $this->license = $license;
 
         return $this;
-    }
-
-    /**
-     * @param mixed $license
-     *
-     * @psalm-assert-if-true  null|LicenseExpression|DisjunctiveLicenseRepository $license
-     */
-    private function isValidLicense($license): bool
-    {
-        return null === $license
-            || $license instanceof LicenseExpression
-            || $license instanceof DisjunctiveLicenseRepository;
     }
 
     public function getHashRepository(): ?HashRepository

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -198,10 +198,9 @@ class Component
      */
     public function setType(string $type): self
     {
-        if (false === Classification::isValidValue($type)) {
-            throw new DomainException("Invalid type: $type");
-        }
-        $this->type = $type;
+        $this->type = Classification::isValidValue($type)
+            ? $type
+            : throw new DomainException("Invalid type: $type");
 
         return $this;
     }

--- a/src/Core/Models/ExternalReference.php
+++ b/src/Core/Models/ExternalReference.php
@@ -78,10 +78,9 @@ class ExternalReference
      */
     public function setType(string $type): self
     {
-        if (false === ExternalReferenceType::isValidValue($type)) {
-            throw new DomainException("Invalid type: $type");
-        }
-        $this->type = $type;
+        $this->type = ExternalReferenceType::isValidValue($type)
+            ? $type
+            : throw new DomainException("Invalid type: $type");
 
         return $this;
     }

--- a/src/Core/Models/ExternalReference.php
+++ b/src/Core/Models/ExternalReference.php
@@ -39,34 +39,25 @@ class ExternalReference
      * Specifies the type of external reference. There are built-in types to describe common
      * references. If a type does not exist for the reference being referred to, use the "other" type.
      *
-     * @var string
-     *
      * @psalm-var ExternalReferenceType::*
      *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $type;
+    private string $type;
 
     /**
      * The URL to the external reference.
      *
-     * @var string
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $url;
+    private string $url;
 
     /**
      * An optional comment describing the external reference.
-     *
-     * @var string|null
      */
-    private $comment;
+    private ?string $comment = null;
 
-    /**
-     * @var HashRepository|null
-     */
-    private $hashRepository;
+    private ?HashRepository $hashRepository = null;
 
     /**
      * @psalm-return  ExternalReferenceType::*

--- a/src/Core/Models/License/AbstractDisjunctiveLicense.php
+++ b/src/Core/Models/License/AbstractDisjunctiveLicense.php
@@ -33,10 +33,8 @@ abstract class AbstractDisjunctiveLicense
     /**
      * The URL to the license file.
      * If specified, a 'license' externalReference should also be specified for completeness.
-     *
-     * @var string|null
      */
-    private $url;
+    private ?string $url = null;
 
     public function getUrl(): ?string
     {

--- a/src/Core/Models/License/DisjunctiveLicenseWithId.php
+++ b/src/Core/Models/License/DisjunctiveLicenseWithId.php
@@ -56,11 +56,11 @@ class DisjunctiveLicenseWithId extends AbstractDisjunctiveLicense
     public static function makeValidated(string $id, LicenseValidator $spdxLicenseValidator): self
     {
         $validId = $spdxLicenseValidator->getLicense($id);
-        if (null === $validId) {
-            throw new DomainException("Invalid SPDX license: $id");
-        }
 
-        return new self($validId);
+        return new self(
+            $validId
+            ?? throw new DomainException("Invalid SPDX license: $id")
+        );
     }
 
     private function __construct(string $id)

--- a/src/Core/Models/License/DisjunctiveLicenseWithId.php
+++ b/src/Core/Models/License/DisjunctiveLicenseWithId.php
@@ -37,10 +37,8 @@ class DisjunctiveLicenseWithId extends AbstractDisjunctiveLicense
      * A valid SPDX license ID.
      *
      * @see \CycloneDX\Core\Spdx\License::validate()
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 
     public function getId(): string
     {
@@ -59,7 +57,7 @@ class DisjunctiveLicenseWithId extends AbstractDisjunctiveLicense
     {
         $validId = $spdxLicenseValidator->getLicense($id);
         if (null === $validId) {
-            throw new DomainException("Invalid SPDX license: $validId");
+            throw new DomainException("Invalid SPDX license: $id");
         }
 
         return new self($validId);

--- a/src/Core/Models/License/DisjunctiveLicenseWithName.php
+++ b/src/Core/Models/License/DisjunctiveLicenseWithName.php
@@ -32,10 +32,8 @@ class DisjunctiveLicenseWithName extends AbstractDisjunctiveLicense
 {
     /**
      * If SPDX does not define the license used, this field may be used to provide the license name.
-     *
-     * @var string|null
      */
-    private $name;
+    private ?string $name = null;
 
     public function getName(): ?string
     {

--- a/src/Core/Models/License/LicenseExpression.php
+++ b/src/Core/Models/License/LicenseExpression.php
@@ -31,11 +31,9 @@ use DomainException;
 class LicenseExpression
 {
     /**
-     * @var string
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $expression;
+    private string $expression;
 
     public function getExpression(): string
     {

--- a/src/Core/Models/License/LicenseExpression.php
+++ b/src/Core/Models/License/LicenseExpression.php
@@ -47,10 +47,9 @@ class LicenseExpression
      */
     public function setExpression(string $expression): self
     {
-        if (false === self::isValid($expression)) {
-            throw new DomainException("Invalid expression: $expression");
-        }
-        $this->expression = $expression;
+        $this->expression = self::isValid($expression)
+            ? $expression
+            : throw new DomainException("Invalid expression: $expression");
 
         return $this;
     }

--- a/src/Core/Models/MetaData.php
+++ b/src/Core/Models/MetaData.php
@@ -32,17 +32,13 @@ class MetaData
 {
     /**
      * The tool(s) used in the creation of the BOM.
-     *
-     * @var ToolRepository|null
      */
-    private $tools;
+    private ?ToolRepository $tools = null;
 
     /**
      * The component that the BOM describes.
-     *
-     * @var Component|null
      */
-    private $component;
+    private ?Component $component = null;
 
     public function getTools(): ?ToolRepository
     {

--- a/src/Core/Models/Tool.php
+++ b/src/Core/Models/Tool.php
@@ -33,38 +33,28 @@ class Tool
 {
     /**
      * The vendor of the tool used to create the BOM.
-     *
-     * @var string|null
      */
-    private $vendor;
+    private ?string $vendor = null;
 
     /**
      * The name of the tool used to create the BOM.
-     *
-     * @var string|null
      */
-    private $name;
+    private ?string $name = null;
 
     /**
      * The version of the tool used to create the BOM.
-     *
-     * @var string|null
      */
-    private $version;
+    private ?string $version = null;
 
     /**
      * The hashes of the tool (if applicable).
-     *
-     * @var HashRepository|null
      */
-    private $hashRepository;
+    private ?HashRepository $hashRepository = null;
 
     /**
      * Provides the ability to document external references related to the tool.
-     *
-     * @var ExternalReferenceRepository|null
      */
-    private $externalReferenceRepository;
+    private ?ExternalReferenceRepository $externalReferenceRepository = null;
 
     public function getVendor(): ?string
     {

--- a/src/Core/Repositories/BomRefRepository.php
+++ b/src/Core/Repositories/BomRefRepository.php
@@ -37,7 +37,7 @@ class BomRefRepository implements \Countable
      *
      * @psalm-var list<BomRef>
      */
-    private $bomRefs = [];
+    private array $bomRefs = [];
 
     public function __construct(BomRef ...$bomRefs)
     {

--- a/src/Core/Repositories/ComponentRepository.php
+++ b/src/Core/Repositories/ComponentRepository.php
@@ -37,7 +37,7 @@ class ComponentRepository implements \Countable
      *
      * @psalm-var list<Component>
      */
-    private $components = [];
+    private array $components = [];
 
     public function __construct(Component ...$components)
     {

--- a/src/Core/Repositories/DisjunctiveLicenseRepository.php
+++ b/src/Core/Repositories/DisjunctiveLicenseRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Repositories;
 
-use CycloneDX\Core\Models\License\AbstractDisjunctiveLicense;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 
@@ -37,16 +36,12 @@ class DisjunctiveLicenseRepository implements \Countable
      *
      * @psalm-var list<DisjunctiveLicenseWithId|DisjunctiveLicenseWithName>
      */
-    private $licenses = [];
+    private array $licenses = [];
 
     /**
      * Unsupported Licenses are filtered out silently.
-     *
-     * @param DisjunctiveLicenseWithId[]|DisjunctiveLicenseWithName[] $licenses
-     *
-     * @psalm-param  list<DisjunctiveLicenseWithId|DisjunctiveLicenseWithName> $licenses
      */
-    public function __construct(AbstractDisjunctiveLicense ...$licenses)
+    public function __construct(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName ...$licenses)
     {
         $this->addLicense(...$licenses);
     }
@@ -55,15 +50,11 @@ class DisjunctiveLicenseRepository implements \Countable
      * Add supported licenses.
      * Unsupported Licenses are filtered out silently.
      *
-     * @param DisjunctiveLicenseWithId[]|DisjunctiveLicenseWithName[] $licenses
-     *
-     * @psalm-param  list<DisjunctiveLicenseWithId|DisjunctiveLicenseWithName> $licenses
-     *
      * @return $this
      */
-    public function addLicense(AbstractDisjunctiveLicense ...$licenses): self
+    public function addLicense(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName ...$licenses): self
     {
-        foreach (array_filter($licenses, [$this, 'isSupportedLicense']) as $license) {
+        foreach ($licenses as $license) {
             if (\in_array($license, $this->licenses, true)) {
                 continue;
             }
@@ -86,14 +77,5 @@ class DisjunctiveLicenseRepository implements \Countable
     public function count(): int
     {
         return \count($this->licenses);
-    }
-
-    /**
-     * @psalm-assert-if-true DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license
-     */
-    private function isSupportedLicense(AbstractDisjunctiveLicense $license): bool
-    {
-        return $license instanceof DisjunctiveLicenseWithId
-            || $license instanceof DisjunctiveLicenseWithName;
     }
 }

--- a/src/Core/Repositories/ExternalReferenceRepository.php
+++ b/src/Core/Repositories/ExternalReferenceRepository.php
@@ -35,7 +35,7 @@ class ExternalReferenceRepository implements \Countable
      *
      * @psalm-var list<ExternalReference>
      */
-    private $externalReferences = [];
+    private array $externalReferences = [];
 
     public function __construct(ExternalReference ...$externalReferences)
     {

--- a/src/Core/Repositories/HashRepository.php
+++ b/src/Core/Repositories/HashRepository.php
@@ -38,7 +38,7 @@ class HashRepository implements \Countable
      *
      * @psalm-var  array<HashAlgorithm::*, string>
      */
-    private $hashDict = [];
+    private array $hashDict = [];
 
     /**
      * Ignores unknown hash algorithms.
@@ -67,8 +67,8 @@ class HashRepository implements \Countable
         foreach ($hashes as $algorithm => $content) {
             try {
                 $this->setHash($algorithm, $content);
-            } catch (DomainException $exception) {
-                unset($exception);
+            } catch (DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Repositories/ToolRepository.php
+++ b/src/Core/Repositories/ToolRepository.php
@@ -37,7 +37,7 @@ class ToolRepository implements \Countable
      *
      * @psalm-var list<Tool>
      */
-    private $tools = [];
+    private array $tools = [];
 
     public function __construct(Tool ...$tools)
     {

--- a/src/Core/Serialize/BaseSerializer.php
+++ b/src/Core/Serialize/BaseSerializer.php
@@ -32,10 +32,7 @@ use CycloneDX\Core\Spec\SpecInterface;
  */
 abstract class BaseSerializer implements SerializerInterface
 {
-    /**
-     * @var SpecInterface
-     */
-    private $spec;
+    private SpecInterface $spec;
 
     public function __construct(SpecInterface $spec)
     {

--- a/src/Core/Serialize/BaseSerializer.php
+++ b/src/Core/Serialize/BaseSerializer.php
@@ -90,12 +90,9 @@ abstract class BaseSerializer implements SerializerInterface
 
         $allComponents = $bom->getComponentRepository()->getComponents();
 
-        $metadata = $bom->getMetaData();
-        if (null !== $metadata) {
-            $metadataComponent = $metadata->getComponent();
-            if (null !== $metadataComponent) {
-                $allComponents[] = $metadataComponent;
-            }
+        $metadataComponent = $bom->getMetaData()?->getComponent();
+        if (null !== $metadataComponent) {
+            $allComponents[] = $metadataComponent;
         }
 
         foreach ($allComponents as $component) {

--- a/src/Core/Serialize/BomRefDiscriminator.php
+++ b/src/Core/Serialize/BomRefDiscriminator.php
@@ -37,14 +37,14 @@ class BomRefDiscriminator
      *
      * @psalm-var list<BomRef>
      */
-    private $bomRefs = [];
+    private array $bomRefs = [];
 
     /**
      * @var string[]|null[]
      *
      * @psalm-var list<?string>
      */
-    private $originalValues = [];
+    private array $originalValues = [];
 
     public function __construct(BomRef ...$bomRefs)
     {

--- a/src/Core/Serialize/DOM/AbstractNormalizer.php
+++ b/src/Core/Serialize/DOM/AbstractNormalizer.php
@@ -30,8 +30,7 @@ namespace CycloneDX\Core\Serialize\DOM;
  */
 abstract class AbstractNormalizer
 {
-    /** @var NormalizerFactory */
-    private $normalizerFactory;
+    private NormalizerFactory $normalizerFactory;
 
     public function __construct(NormalizerFactory $normalizerFactory)
     {

--- a/src/Core/Serialize/DOM/NormalizerFactory.php
+++ b/src/Core/Serialize/DOM/NormalizerFactory.php
@@ -63,10 +63,9 @@ class NormalizerFactory
      */
     public function setSpec(SpecInterface $spec): self
     {
-        if (false === $spec->isSupportedFormat(self::FORMAT)) {
-            throw new DomainException('Unsupported format "'.self::FORMAT.'" for spec '.$spec->getVersion());
-        }
-        $this->spec = $spec;
+        $this->spec = $spec->isSupportedFormat(self::FORMAT)
+            ? $spec
+            : throw new DomainException('Unsupported format "'.self::FORMAT.'" for spec '.$spec->getVersion());
 
         return $this;
     }

--- a/src/Core/Serialize/DOM/NormalizerFactory.php
+++ b/src/Core/Serialize/DOM/NormalizerFactory.php
@@ -36,14 +36,11 @@ class NormalizerFactory
     public const FORMAT = Format::XML;
 
     /**
-     * @var SpecInterface
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $spec;
+    private SpecInterface $spec;
 
-    /** @var DOMDocument */
-    private $document;
+    private DOMDocument $document;
 
     /**
      * @throws DomainException when the spec does not support XML format

--- a/src/Core/Serialize/DOM/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/BomNormalizer.php
@@ -102,15 +102,13 @@ class BomNormalizer extends AbstractNormalizer
 
         if (false === $factory->getSpec()->supportsMetaData()) {
             // prevent possible information loss: metadata cannot be rendered -> put it to bom
-            if (null !== ($m = $bom->getMetaData())
-                && null !== ($mc = $m->getComponent())
-                && null !== ($mcr = $mc->getExternalReferenceRepository())
-            ) {
+            $mcr = $bom->getMetaData()?->getComponent()?->getExternalReferenceRepository();
+            if (null !== $mcr) {
                 $externalReferenceRepository = null !== $externalReferenceRepository
                     ? (clone $externalReferenceRepository)->addExternalReference(...$mcr->getExternalReferences())
                     : $mcr;
             }
-            unset($m, $mc, $mcr);
+            unset($mcr);
         }
 
         if (null === $externalReferenceRepository) {

--- a/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentNormalizer.php
@@ -103,10 +103,7 @@ class ComponentNormalizer extends AbstractNormalizer
         );
     }
 
-    /**
-     * @param LicenseExpression|DisjunctiveLicenseRepository|null $license
-     */
-    private function normalizeLicense($license): ?DOMElement
+    private function normalizeLicense(LicenseExpression|DisjunctiveLicenseRepository|null $license): ?DOMElement
     {
         /**
          * @var DOMElement[] $licenses

--- a/src/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ComponentRepositoryNormalizer.php
@@ -45,8 +45,8 @@ class ComponentRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getComponents() as $component) {
             try {
                 $components[] = $normalizer->normalize($component);
-            } catch (\DomainException $exception) {
-                continue;
+            } catch (\DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/DOM/Normalizers/DependenciesNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DependenciesNormalizer.php
@@ -55,14 +55,10 @@ class DependenciesNormalizer extends AbstractNormalizer
         }
 
         $allComponentRefs = array_map(
-            static function (Component $c): BomRef {
-                return $c->getBomRef();
-            },
+            static fn (Component $c): BomRef => $c->getBomRef(),
             $allComponents
         );
-        $isKnownRef = static function (BomRef $r) use ($allComponentRefs): bool {
-            return \in_array($r, $allComponentRefs, true);
-        };
+        $isKnownRef = static fn (BomRef $r): bool => \in_array($r, $allComponentRefs, true);
 
         $dependencies = [];
         foreach ($allComponents as $component) {

--- a/src/Core/Serialize/DOM/Normalizers/DependenciesNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DependenciesNormalizer.php
@@ -46,12 +46,9 @@ class DependenciesNormalizer extends AbstractNormalizer
     {
         $allComponents = $bom->getComponentRepository()->getComponents();
 
-        $metadata = $bom->getMetaData();
-        if (null !== $metadata) {
-            $mainComponent = $metadata->getComponent();
-            if (null !== $mainComponent) {
-                $allComponents[] = $mainComponent;
-            }
+        $mainComponent = $bom->getMetaData()?->getComponent();
+        if (null !== $mainComponent) {
+            $allComponents[] = $mainComponent;
         }
 
         $allComponentRefs = array_map(

--- a/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizer.php
@@ -54,7 +54,7 @@ class DisjunctiveLicenseNormalizer extends AbstractNormalizer
             $id = null;
             $name = $license->getName();
         } else {
-            throw new InvalidArgumentException('Unsupported license class: '.\get_class($license));
+            throw new InvalidArgumentException('Unsupported license class: '.$license::class);
         }
 
         $document = $this->getNormalizerFactory()->getDocument();

--- a/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizer.php
@@ -25,12 +25,10 @@ namespace CycloneDX\Core\Serialize\DOM\Normalizers;
 
 use CycloneDX\Core\Helpers\SimpleDomTrait;
 use CycloneDX\Core\Helpers\XmlTrait;
-use CycloneDX\Core\Models\License\AbstractDisjunctiveLicense;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Serialize\DOM\AbstractNormalizer;
 use DOMElement;
-use InvalidArgumentException;
 
 /**
  * @author jkowalleck
@@ -40,21 +38,14 @@ class DisjunctiveLicenseNormalizer extends AbstractNormalizer
     use SimpleDomTrait;
     use XmlTrait;
 
-    /**
-     * @psalm-assert DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license
-     *
-     * @throws InvalidArgumentException
-     */
-    public function normalize(AbstractDisjunctiveLicense $license): DOMElement
+    public function normalize(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): DOMElement
     {
         if ($license instanceof DisjunctiveLicenseWithId) {
             $id = $license->getId();
             $name = null;
-        } elseif ($license instanceof DisjunctiveLicenseWithName) {
+        } else {
             $id = null;
             $name = $license->getName();
-        } else {
-            throw new InvalidArgumentException('Unsupported license class: '.$license::class);
         }
 
         $document = $this->getNormalizerFactory()->getDocument();

--- a/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -48,8 +48,8 @@ class DisjunctiveLicenseRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getLicenses() as $license) {
             try {
                 $licenses[] = $normalizer->normalize($license);
-            } catch (\InvalidArgumentException $exception) {
-                continue;
+            } catch (\InvalidArgumentException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -46,11 +46,7 @@ class DisjunctiveLicenseRepositoryNormalizer extends AbstractNormalizer
 
         $normalizer = $this->getNormalizerFactory()->makeForDisjunctiveLicense();
         foreach ($repo->getLicenses() as $license) {
-            try {
-                $licenses[] = $normalizer->normalize($license);
-            } catch (\InvalidArgumentException) {
-                // pass
-            }
+            $licenses[] = $normalizer->normalize($license);
         }
 
         return $licenses;

--- a/src/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
@@ -45,10 +45,8 @@ class ExternalReferenceRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getExternalReferences() as $externalReference) {
             try {
                 $externalReferences[] = $normalizer->normalize($externalReference);
-            } catch (\DomainException $exception) {
-                continue;
-            } catch (\UnexpectedValueException $exception) {
-                continue;
+            } catch (\DomainException|\UnexpectedValueException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/DOM/Normalizers/HashRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/HashRepositoryNormalizer.php
@@ -50,7 +50,8 @@ class HashRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getHashes() as $algorithm => $content) {
             try {
                 $hashes[] = $hashNormalizer->normalize($algorithm, $content);
-            } catch (\DomainException $exception) {
+            } catch (\DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/DOM/Normalizers/MetaDataNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/MetaDataNormalizer.php
@@ -70,7 +70,7 @@ class MetaDataNormalizer extends AbstractNormalizer
 
         try {
             return $this->getNormalizerFactory()->makeForComponent()->normalize($component);
-        } catch (\DomainException $exception) {
+        } catch (\DomainException) {
             return null;
         }
     }

--- a/src/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizer.php
+++ b/src/Core/Serialize/DOM/Normalizers/ToolRepositoryNormalizer.php
@@ -45,8 +45,8 @@ class ToolRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getTools() as $tool) {
             try {
                 $tools[] = $normalizer->normalize($tool);
-            } catch (\DomainException $exception) {
-                continue;
+            } catch (\DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/JSON/AbstractNormalizer.php
+++ b/src/Core/Serialize/JSON/AbstractNormalizer.php
@@ -30,8 +30,7 @@ namespace CycloneDX\Core\Serialize\JSON;
  */
 abstract class AbstractNormalizer
 {
-    /** @var NormalizerFactory */
-    private $normalizerFactory;
+    private NormalizerFactory $normalizerFactory;
 
     public function __construct(NormalizerFactory $normalizerFactory)
     {

--- a/src/Core/Serialize/JSON/NormalizerFactory.php
+++ b/src/Core/Serialize/JSON/NormalizerFactory.php
@@ -59,10 +59,9 @@ class NormalizerFactory
      */
     public function setSpec(SpecInterface $spec): self
     {
-        if (false === $spec->isSupportedFormat(self::FORMAT)) {
-            throw new DomainException('Unsupported format "'.self::FORMAT.'" for spec '.$spec->getVersion());
-        }
-        $this->spec = $spec;
+        $this->spec = $spec->isSupportedFormat(self::FORMAT)
+            ? $spec
+            : throw new DomainException('Unsupported format "'.self::FORMAT.'" for spec '.$spec->getVersion());
 
         return $this;
     }

--- a/src/Core/Serialize/JSON/NormalizerFactory.php
+++ b/src/Core/Serialize/JSON/NormalizerFactory.php
@@ -35,11 +35,9 @@ class NormalizerFactory
     public const FORMAT = Format::JSON;
 
     /**
-     * @var SpecInterface
-     *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $spec;
+    private SpecInterface $spec;
 
     /**
      * @throws DomainException when the spec does not support JSON format

--- a/src/Core/Serialize/JSON/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/BomNormalizer.php
@@ -82,15 +82,13 @@ class BomNormalizer extends AbstractNormalizer
 
         if (false === $factory->getSpec()->supportsMetaData()) {
             // prevent possible information loss: metadata cannot be rendered -> put it to bom
-            if (null !== ($m = $bom->getMetaData())
-                && null !== ($mc = $m->getComponent())
-                && null !== ($mcr = $mc->getExternalReferenceRepository())
-            ) {
+            $mcr = $bom->getMetaData()?->getComponent()?->getExternalReferenceRepository();
+            if (null !== $mcr) {
                 $externalReferenceRepository = null !== $externalReferenceRepository
                     ? (clone $externalReferenceRepository)->addExternalReference(...$mcr->getExternalReferences())
                     : $mcr;
             }
-            unset($m, $mc, $mcr);
+            unset($mcr);
         }
 
         if (null === $externalReferenceRepository) {

--- a/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentNormalizer.php
@@ -84,10 +84,7 @@ class ComponentNormalizer extends AbstractNormalizer
         );
     }
 
-    /**
-     * @param LicenseExpression|DisjunctiveLicenseRepository|null $license
-     */
-    private function normalizeLicense($license): ?array
+    private function normalizeLicense(LicenseExpression|DisjunctiveLicenseRepository|null $license): ?array
     {
         if ($license instanceof LicenseExpression) {
             return $this->normalizeLicenseExpression($license);

--- a/src/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ComponentRepositoryNormalizer.php
@@ -42,8 +42,8 @@ class ComponentRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getComponents() as $component) {
             try {
                 $components[] = $normalizer->normalize($component);
-            } catch (\DomainException $exception) {
-                continue;
+            } catch (\DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/JSON/Normalizers/DependenciesNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DependenciesNormalizer.php
@@ -57,14 +57,10 @@ class DependenciesNormalizer extends AbstractNormalizer
         }
 
         $allComponentRefs = array_map(
-            static function (Component $c): BomRef {
-                return $c->getBomRef();
-            },
+            static fn (Component $c): BomRef => $c->getBomRef(),
             $allComponents
         );
-        $isKnownRef = static function (BomRef $r) use ($allComponentRefs): bool {
-            return \in_array($r, $allComponentRefs, true);
-        };
+        $isKnownRef = static fn (BomRef $r): bool => \in_array($r, $allComponentRefs, true);
 
         $dependencies = [];
         foreach ($allComponents as $component) {

--- a/src/Core/Serialize/JSON/Normalizers/DependenciesNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DependenciesNormalizer.php
@@ -48,12 +48,9 @@ class DependenciesNormalizer extends AbstractNormalizer
     {
         $allComponents = $bom->getComponentRepository()->getComponents();
 
-        $metadata = $bom->getMetaData();
-        if (null !== $metadata) {
-            $mainComponent = $metadata->getComponent();
-            if (null !== $mainComponent) {
-                $allComponents[] = $mainComponent;
-            }
+        $mainComponent = $bom->getMetaData()?->getComponent();
+        if (null !== $mainComponent) {
+            $allComponents[] = $mainComponent;
         }
 
         $allComponentRefs = array_map(

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
@@ -24,11 +24,9 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialize\JSON\Normalizers;
 
 use CycloneDX\Core\Helpers\NullAssertionTrait;
-use CycloneDX\Core\Models\License\AbstractDisjunctiveLicense;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
-use InvalidArgumentException;
 
 /**
  * @author jkowalleck
@@ -37,21 +35,14 @@ class DisjunctiveLicenseNormalizer extends AbstractNormalizer
 {
     use NullAssertionTrait;
 
-    /**
-     * @psalm-assert DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license
-     *
-     * @throws InvalidArgumentException
-     */
-    public function normalize(AbstractDisjunctiveLicense $license): array
+    public function normalize(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): array
     {
         if ($license instanceof DisjunctiveLicenseWithId) {
             $id = $license->getId();
             $name = null;
-        } elseif ($license instanceof DisjunctiveLicenseWithName) {
+        } else {
             $id = null;
             $name = $license->getName();
-        } else {
-            throw new InvalidArgumentException('Unsupported license class: '.$license::class);
         }
 
         return ['license' => array_filter(

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizer.php
@@ -51,7 +51,7 @@ class DisjunctiveLicenseNormalizer extends AbstractNormalizer
             $id = null;
             $name = $license->getName();
         } else {
-            throw new InvalidArgumentException('Unsupported license class: '.\get_class($license));
+            throw new InvalidArgumentException('Unsupported license class: '.$license::class);
         }
 
         return ['license' => array_filter(

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -25,7 +25,6 @@ namespace CycloneDX\Core\Serialize\JSON\Normalizers;
 
 use CycloneDX\Core\Repositories\DisjunctiveLicenseRepository;
 use CycloneDX\Core\Serialize\JSON\AbstractNormalizer;
-use InvalidArgumentException;
 
 /**
  * @author jkowalleck

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -40,8 +40,8 @@ class DisjunctiveLicenseRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getLicenses() as $license) {
             try {
                 $licenses[] = $normalizer->normalize($license);
-            } catch (InvalidArgumentException $exception) {
-                continue;
+            } catch (InvalidArgumentException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizer.php
@@ -38,11 +38,7 @@ class DisjunctiveLicenseRepositoryNormalizer extends AbstractNormalizer
 
         $normalizer = $this->getNormalizerFactory()->makeForDisjunctiveLicense();
         foreach ($repo->getLicenses() as $license) {
-            try {
-                $licenses[] = $normalizer->normalize($license);
-            } catch (InvalidArgumentException) {
-                // pass
-            }
+            $licenses[] = $normalizer->normalize($license);
         }
 
         return $licenses;

--- a/src/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ExternalReferenceRepositoryNormalizer.php
@@ -44,7 +44,7 @@ class ExternalReferenceRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getExternalReferences() as $externalReference) {
             try {
                 $item = $normalizer->normalize($externalReference);
-            } catch (\DomainException $exception) {
+            } catch (\DomainException) {
                 continue;
             }
             if (false === empty($item)) {

--- a/src/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/HashRepositoryNormalizer.php
@@ -39,8 +39,8 @@ class HashRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getHashes() as $algorithm => $content) {
             try {
                 $hashes[] = $normalizer->normalize($algorithm, $content);
-            } catch (\DomainException $exception) {
-                continue;
+            } catch (\DomainException) {
+                // pass
             }
         }
 

--- a/src/Core/Serialize/JSON/Normalizers/MetaDataNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/MetaDataNormalizer.php
@@ -66,7 +66,7 @@ class MetaDataNormalizer extends AbstractNormalizer
 
         try {
             return $this->getNormalizerFactory()->makeForComponent()->normalize($component);
-        } catch (\DomainException $exception) {
+        } catch (\DomainException) {
             return null;
         }
     }

--- a/src/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizer.php
+++ b/src/Core/Serialize/JSON/Normalizers/ToolRepositoryNormalizer.php
@@ -44,7 +44,7 @@ class ToolRepositoryNormalizer extends AbstractNormalizer
         foreach ($repo->getTools() as $tool) {
             try {
                 $item = $normalizer->normalize($tool);
-            } catch (\DomainException $exception) {
+            } catch (\DomainException) {
                 continue;
             }
             if (false === empty($item)) {

--- a/src/Core/Spdx/License.php
+++ b/src/Core/Spdx/License.php
@@ -90,9 +90,11 @@ class License
         }
 
         $file = $this->getResourcesFile();
-        $json = file_exists($file) ? file_get_contents($file) : false;
+        $json = file_exists($file)
+            ? file_get_contents($file)
+            : throw new RuntimeException("Missing licenses file: $file");
         if (false === $json) {
-            throw new RuntimeException("Missing licenses file: $file");
+            throw new RuntimeException("Failed to get content from licenses file: $file");
         }
 
         try {

--- a/src/Core/Spdx/License.php
+++ b/src/Core/Spdx/License.php
@@ -34,6 +34,8 @@ use RuntimeException;
  */
 class License
 {
+    private bool $initialized = false;
+
     /**
      * @var string[]
      *
@@ -41,7 +43,7 @@ class License
      *
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $licenses;
+    private array $licenses;
 
     /**
      * @return string[]
@@ -78,12 +80,10 @@ class License
 
     /**
      * @throws RuntimeException
-     *
-     * @psalm-suppress RedundantConditionGivenDocblockType
      */
     public function loadLicenses(): void
     {
-        if (null !== $this->licenses) {
+        if ($this->initialized) {
             // @codeCoverageIgnoreStart
             return;
             // @codeCoverageIgnoreEnd
@@ -98,7 +98,7 @@ class License
         try {
             /**
              * list of strings, as asserted by an integration test:
-             * {@see \CycloneDX\Tests\unit\Core\Spdx\LicenseTest::testShippedLicensesFile()}.
+             * {@see \CycloneDX\Tests\Core\Spdx\LicenseTest::testShippedLicensesFile()}.
              *
              * @var string[] $licenses
              *
@@ -114,5 +114,7 @@ class License
         foreach ($licenses as $license) {
             $this->licenses[strtolower($license)] = $license;
         }
+
+        $this->initialized = true;
     }
 }

--- a/src/Core/Validation/BaseValidator.php
+++ b/src/Core/Validation/BaseValidator.php
@@ -31,10 +31,7 @@ use CycloneDX\Core\Spec\Version;
  */
 abstract class BaseValidator implements ValidatorInterface
 {
-    /**
-     * @var SpecInterface
-     */
-    private $spec;
+    private SpecInterface $spec;
 
     public function __construct(SpecInterface $spec)
     {

--- a/src/Core/Validation/Errors/JsonValidationError.php
+++ b/src/Core/Validation/Errors/JsonValidationError.php
@@ -34,9 +34,10 @@ class JsonValidationError extends ValidationError
     /**
      * @internal as this function may be affected by breaking changes without notice
      *
-     * @return static
+     * @psalm-suppress MoreSpecificReturnType
+     * @psalm-suppress LessSpecificReturnStatement
      */
-    public static function fromJsonSchemaInvalidValue(JsonSchema\InvalidValue $error): self
+    public static function fromJsonSchemaInvalidValue(JsonSchema\InvalidValue $error): static
     {
         return parent::fromThrowable($error);
     }

--- a/src/Core/Validation/Errors/XmlValidationError.php
+++ b/src/Core/Validation/Errors/XmlValidationError.php
@@ -33,17 +33,13 @@ class XmlValidationError extends ValidationError
 {
     /**
      * keep for internal debug purposes.
-     *
-     * @var object|null
      */
-    private $debugError;
+    private ?object $debugError = null;
 
     /**
      * @internal as this function may be affected by breaking changes without notice
-     *
-     * @return static
      */
-    public static function fromLibXMLError(LibXMLError $error): self
+    public static function fromLibXMLError(LibXMLError $error): static
     {
         $i = new static($error->message);
         $i->debugError = $error;

--- a/src/Core/Validation/ValidationError.php
+++ b/src/Core/Validation/ValidationError.php
@@ -29,18 +29,14 @@ namespace CycloneDX\Core\Validation;
 class ValidationError
 {
     /**
-     * @var string
-     *
      * @readonly
      */
-    private $message;
+    private string $message;
 
     /**
      * keep for internal debug purposes.
-     *
-     * @var object|null
      */
-    private $error;
+    private ?object $error = null;
 
     final protected function __construct(string $message)
     {
@@ -59,10 +55,8 @@ class ValidationError
 
     /**
      * @internal as this function may be affected by breaking changes without notice
-     *
-     * @return static
      */
-    public static function fromThrowable(\Throwable $error): self
+    public static function fromThrowable(\Throwable $error): static
     {
         $i = new static($error->getMessage());
         $i->error = $error;

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -29,7 +29,6 @@ use CycloneDX\Core\Validation\BaseValidator;
 use CycloneDX\Core\Validation\Errors\JsonValidationError;
 use CycloneDX\Core\Validation\Exceptions\FailedLoadingSchemaException;
 use CycloneDX\Core\Validation\Helpers\JsonSchemaRemoteRefProviderForSnapshotResources;
-use CycloneDX\Core\Validation\ValidationError;
 use Exception;
 use JsonException;
 use Swaggest\JsonSchema;
@@ -59,10 +58,8 @@ class JsonValidator extends BaseValidator
      *
      * @throws FailedLoadingSchemaException if schema file unknown or not readable
      * @throws JsonException                if loading the JSON failed
-     *
-     * @return JsonValidationError|null
      */
-    public function validateString(string $string): ?ValidationError
+    public function validateString(string $string): ?JsonValidationError
     {
         return $this->validateData(
             $this->loadDataFromJson($string)

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -28,7 +28,6 @@ use CycloneDX\Core\Spec\Version;
 use CycloneDX\Core\Validation\BaseValidator;
 use CycloneDX\Core\Validation\Errors\XmlValidationError;
 use CycloneDX\Core\Validation\Exceptions\FailedLoadingSchemaException;
-use CycloneDX\Core\Validation\ValidationError;
 use DOMDocument;
 use DOMException;
 
@@ -57,10 +56,8 @@ class XmlValidator extends BaseValidator
      *
      * @throws FailedLoadingSchemaException if schema file unknown or not readable
      * @throws DOMException                 if loading the DOM failed
-     *
-     * @return XmlValidationError|null
      */
-    public function validateString(string $string): ?ValidationError
+    public function validateString(string $string): ?XmlValidationError
     {
         return $this->validateDom(
             $this->loadDomFromXml($string)

--- a/tests/Core/Models/ComponentTest.php
+++ b/tests/Core/Models/ComponentTest.php
@@ -145,14 +145,6 @@ class ComponentTest extends TestCase
         yield 'expression' => [$this->createStub(LicenseExpression::class)];
     }
 
-    public function testLicensesSetterGetterThrowsOnInvalidArgument(): void
-    {
-        $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessageMatches('/invalid license type/i');
-
-        $this->component->setLicense(new \stdClass());
-    }
-
     // endregion licenses setter&getter
 
     // region hashes setter&getter

--- a/tests/Core/ResourcesTest.php
+++ b/tests/Core/ResourcesTest.php
@@ -51,7 +51,7 @@ class ResourcesTest extends TestCase
     {
         $constants = (new \ReflectionClass(Resources::class))->getConstants();
         foreach ($constants as $name => $value) {
-            if (0 === strpos($name, 'FILE')) {
+            if (str_starts_with($name, 'FILE')) {
                 yield $name => [$value];
             }
         }

--- a/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseNormalizerTest.php
@@ -85,16 +85,4 @@ class DisjunctiveLicenseNormalizerTest extends TestCase
             ];
         }
     }
-
-    public function testNormalizeThrowsOnUnknown(): void
-    {
-        $license = $this->createStub(AbstractDisjunctiveLicense::class);
-        $factory = $this->createMock(NormalizerFactory::class);
-        $normalizer = new DisjunctiveLicenseNormalizer($factory);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/unsupported license class/i');
-
-        $normalizer->normalize($license);
-    }
 }

--- a/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/DOM/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
@@ -61,23 +61,4 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
 
         self::assertSame([$dummy1, $dummy2], $normalized);
     }
-
-    public function testNormalizeSkipsOnThrows(): void
-    {
-        $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
-        $license2 = $this->createStub(DisjunctiveLicenseWithName::class);
-        $licenseNormalizer = $this->createMock(DisjunctiveLicenseNormalizer::class);
-        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['makeForDisjunctiveLicense' => $licenseNormalizer]);
-        $normalizer = new DisjunctiveLicenseRepositoryNormalizer($factory);
-        $repo = $this->createStub(DisjunctiveLicenseRepository::class);
-        $repo->method('getLicenses')->willReturn([$license1, $license2]);
-
-        $licenseNormalizer->expects(self::exactly(2))->method('normalize')
-            ->withConsecutive([$license1], [$license2])
-            ->willThrowException(new \InvalidArgumentException());
-
-        $got = $normalizer->normalize($repo);
-
-        self::assertSame([], $got);
-    }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseNormalizerTest.php
@@ -77,24 +77,12 @@ class DisjunctiveLicenseNormalizerTest extends TestCase
         yield 'optional url' => [
             $this->createConfiguredMock(DisjunctiveLicenseWithName::class, [
                 'getName' => 'foo',
-                'getUrl' => 'http://foo.bar',
+                'getUrl' => 'https://foo.bar',
                 ]),
             ['license' => [
                 'name' => 'foo',
-                'url' => 'http://foo.bar',
+                'url' => 'https://foo.bar',
             ]],
         ];
-    }
-
-    public function testNormalizeThrowsOnUnknown(): void
-    {
-        $license = $this->createStub(AbstractDisjunctiveLicense::class);
-        $factory = $this->createMock(NormalizerFactory::class);
-        $normalizer = new DisjunctiveLicenseNormalizer($factory);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/unsupported license class/i');
-
-        $normalizer->normalize($license);
     }
 }

--- a/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialize/JSON/Normalizers/DisjunctiveLicenseRepositoryNormalizerTest.php
@@ -58,23 +58,4 @@ class DisjunctiveLicenseRepositoryNormalizerTest extends TestCase
 
         self::assertSame([['dummy1'], ['dummy2']], $normalized);
     }
-
-    public function testNormalizeSkipOnThrows(): void
-    {
-        $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
-        $license2 = $this->createStub(DisjunctiveLicenseWithName::class);
-        $licenseNormalizer = $this->createMock(DisjunctiveLicenseNormalizer::class);
-        $factory = $this->createConfiguredMock(NormalizerFactory::class, ['makeForDisjunctiveLicense' => $licenseNormalizer]);
-        $normalizer = new DisjunctiveLicenseRepositoryNormalizer($factory);
-        $repo = $this->createStub(DisjunctiveLicenseRepository::class);
-        $repo->method('getLicenses')->willReturn([$license1, $license2]);
-
-        $licenseNormalizer->expects(self::exactly(2))->method('normalize')
-            ->withConsecutive([$license1], [$license2])
-            ->willThrowException(new \InvalidArgumentException());
-
-        $got = $normalizer->normalize($repo);
-
-        self::assertSame([], $got);
-    }
 }

--- a/tools/composer-require-checker/composer.json
+++ b/tools/composer-require-checker/composer.json
@@ -3,7 +3,7 @@
     "description": "composer-require-checker",
     "type": "metapackage",
     "require-dev": {
-        "maglnet/composer-require-checker": "3.8.0",
+        "maglnet/composer-require-checker": "4.2.0",
         "roave/security-advisories": "dev-latest"
     },
     "prefer-stable": true,

--- a/tools/phpmd/composer.json
+++ b/tools/phpmd/composer.json
@@ -3,7 +3,7 @@
     "description": "phpmd",
     "type": "metapackage",
     "require-dev": {
-        "phpmd/phpmd": "2.12.0",
+        "phpmd/phpmd": "2.13.0",
         "roave/security-advisories": "dev-latest"
     },
     "prefer-stable": true,


### PR DESCRIPTION
fixes #6
fixes #114

----

* BREAKING changes
  * Dropped support for php v7.3 and v7.4. (via [#125])
  * API
    * Some methods now enforce the use of concrete union types instead of protocols.  (via [#125])
      Affected the usages of `\CycloneDX\Core\Models\License\AbstractDisjunctiveLicense` and methods that used license-related classes.
      This was possible due to php8's UnionType language feature.
* Changed
  * Some methods no longer throw `InvalidArgumentException`. (via [#125])  
    This was possible by enforcing correct typing on language level.
* Removed
  * The public usage of the internal class `\CycloneDX\Core\Models\License\AbstractDisjunctiveLicense`. (via [#125])  
    This was possible due php8's UnionType language feature.
* Style
  * All class properties now enforce the correct types. (via [#125])  
    This is considered a non-breaking change, because the types were already correctly annotated.  
    This was possible due to php74's features and php8's UnionType language feature.
  * Migrated internals to php8 language features. (via [#125])