### PR TITLE
`ExternalReferenceNormalizer::normalize()` is less likely tho throw `DomainException`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,8 +30,6 @@ API changes
     This was possible by enforcing correct typing on PHP8 language level.
 * `\CycloneDX\Core\Enum` namespace
   * Added class constant `ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4 ([#57] via [#65])
-* `\CycloneDX\Core\Factories` namespace
-  * No noteworthy changes
 * `\CycloneDX\Core\Models` namespace
   * `Bom` class
     * BREAKING: renamed methods `{get,set}ComponentRepository()` -> `{get,set}Components()` ([#133] via [#131])
@@ -56,12 +54,6 @@ API changes
   * `Licenses` namespace
     * `AbstractDisjunctiveLicense`
        * BREAKING: Removed this class (via [#125], [#131])
-    * `DisjunctiveLicenseWithId` class
-      * No noteworthy changes.
-    * `DisjunctiveLicenseWithName` class
-      * No noteworthy changes.
-    * `LicenseExpression` class
-      * No noteworthy changes.
   * `MetaData` class
     * BREAKING: renamed class to `Metadata` ([#133] via [#131])  
       Even though PHP is case-insensitive with class names, autoloaders are not. Therefore, this is considered a breaking change.
@@ -111,9 +103,10 @@ API changes
     * `ExternalReferenceNormalizer` classes
       * Changed the method `normalize()` to actually throw `\DomainException` when `\ExternalReference`'s type was not supported by the spec. (via [#65])  
         This is considered a non-breaking change, because the behaviour was already documented in the API, even though there was no need for an implementation before.
+    * `ExternalReferenceNormalizer` classes
+      * Changed, so that it tries to convert unsupported types to "other", before it throws an `\DomainException` ([#137] via [#147])
 * `\CycloneDX\Core\Spdx` namespace
-  * `License` class
-    * BREAKING: renamed the class to `LicenseValidator` ([#133] via [#143])
+  * BREAKING: renamed the class `License` -> `LicenseValidator` ([#133] via [#143])
 * `\CycloneDX\Core\Spec` namespace
   * BREAKING: completely reworked everything ([#139] via [#142])  
     See the code base for references
@@ -138,6 +131,7 @@ API changes
 [#125]: https://github.com/CycloneDX/cyclonedx-php-library/pull/125
 [#131]: https://github.com/CycloneDX/cyclonedx-php-library/pull/131
 [#133]: https://github.com/CycloneDX/cyclonedx-php-library/pull/133
+[#137]: https://github.com/CycloneDX/cyclonedx-php-library/issues/137
 [#139]: https://github.com/CycloneDX/cyclonedx-php-library/issues/139
 [#142]: https://github.com/CycloneDX/cyclonedx-php-library/pull/142
 [#143]: https://github.com/CycloneDX/cyclonedx-php-library/pull/143

--- a/src/Core/Serialization/DOM/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/ExternalReferenceNormalizer.php
@@ -26,6 +26,7 @@ namespace CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\_helpers\SimpleDomTrait;
 use CycloneDX\Core\_helpers\XmlTrait;
 use CycloneDX\Core\Collections\HashDictionary;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Serialization\DOM\_BaseNormalizer;
 use DomainException;
@@ -51,7 +52,11 @@ class ExternalReferenceNormalizer extends _BaseNormalizer
 
         $type = $externalReference->getType();
         if (false === $spec->isSupportedExternalReferenceType($type)) {
-            throw new DomainException("ExternalReference has unsupported type: $type");
+            // prevent information-loss -> try transfer to OTHER
+            $type = ExternalReferenceType::OTHER;
+            if (false === $spec->isSupportedExternalReferenceType($type)) {
+                throw new DomainException('ExternalReference has unsupported type: '.$externalReference->getType());
+            }
         }
 
         $refURI = $externalReference->getUrl();

--- a/src/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizer.php
@@ -25,6 +25,7 @@ namespace CycloneDX\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\_helpers\NullAssertionTrait;
 use CycloneDX\Core\Collections\HashDictionary;
+use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Serialization\JSON\_BaseNormalizer;
 use DomainException;
@@ -41,9 +42,14 @@ class ExternalReferenceNormalizer extends _BaseNormalizer
      */
     public function normalize(ExternalReference $externalReference): array
     {
+        $spec = $this->getNormalizerFactory()->getSpec();
         $type = $externalReference->getType();
-        if (false === $this->getNormalizerFactory()->getSpec()->isSupportedExternalReferenceType($type)) {
-            throw new DomainException("ExternalReference has unsupported type: $type");
+        if (false === $spec->isSupportedExternalReferenceType($type)) {
+            // prevent information-loss -> try transfer to OTHER
+            $type = ExternalReferenceType::OTHER;
+            if (false === $spec->isSupportedExternalReferenceType($type)) {
+                throw new DomainException('ExternalReference has unsupported type: '.$externalReference->getType());
+            }
         }
 
         return array_filter(

--- a/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizerTest.php
@@ -64,6 +64,36 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
         ], $actual);
     }
 
+    public function testNormalizeTypeConvertIfNotSupported(): void
+    {
+        $spec = $this->createMock(Spec::class);
+        $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
+            'getSPec' => $spec,
+        ]);
+        $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
+        $extRef = $this->createConfiguredMock(ExternalReference::class, [
+            'getType' => 'someType',
+            'getUrl' => 'someUrl',
+        ]);
+
+        $spec->expects(self::exactly(2))
+            ->method('isSupportedExternalReferenceType')
+            ->withConsecutive(['someType'], ['other'])
+            ->willReturnMap([
+                ['someType', false],
+                ['other', true],
+            ]);
+
+        $actual = $normalizer->normalize($extRef);
+
+        self::assertSame([
+            'type' => 'other',
+            'url' => 'someUrl',
+            // comment omitted
+            // hashes omitted
+        ], $actual);
+    }
+
     public function testThrowOnUnsupportedRefType(): void
     {
         $spec = $this->createMock(Spec::class);
@@ -78,9 +108,9 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
             'getHashes' => $this->createMock(HashDictionary::class),
         ]);
 
-        $spec->expects(self::atLeastOnce())
+        $spec->expects(self::exactly(2))
             ->method('isSupportedExternalReferenceType')
-            ->with('someType')
+            ->withConsecutive(['someType'], ['other'])
             ->willReturn(false);
 
         $this->expectException(\DomainException::class);


### PR DESCRIPTION
closes #137 