### PR TITLE
style: cs-fixer apply global_namespace_import

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -38,9 +38,10 @@ return (new PhpCsFixer\Config())
             '@Symfony' => true,
             '@Symfony:risky' => true,
             'declare_strict_types' => true,
-            'phpdoc_order' => true,
             'header_comment' => ['header' => $header],
+            'global_namespace_import' => true,
             'fopen_flags' => ['b_mode' => true],
+            'phpdoc_order' => true,
             'phpdoc_to_comment' => [
                 'ignored_tags' => [
                 //    'psalm-var', // needed when PSALM introduced some issues that only manual hints can solve

--- a/src/Core/Collections/BomRefRepository.php
+++ b/src/Core/Collections/BomRefRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Models\BomRef;
 
 /**
@@ -30,7 +31,7 @@ use CycloneDX\Core\Models\BomRef;
  *
  * @author jkowalleck
  */
-class BomRefRepository implements \Countable
+class BomRefRepository implements Countable
 {
     /**
      * @var BomRef[]

--- a/src/Core/Collections/ComponentRepository.php
+++ b/src/Core/Collections/ComponentRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Models\Component;
 
 /**
@@ -30,7 +31,7 @@ use CycloneDX\Core\Models\Component;
  *
  * @author jkowalleck
  */
-class ComponentRepository implements \Countable
+class ComponentRepository implements Countable
 {
     /**
      * @var Component[]

--- a/src/Core/Collections/ExternalReferenceRepository.php
+++ b/src/Core/Collections/ExternalReferenceRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Models\ExternalReference;
 
 /**
@@ -30,7 +31,7 @@ use CycloneDX\Core\Models\ExternalReference;
  *
  * @author jkowalleck
  */
-class ExternalReferenceRepository implements \Countable
+class ExternalReferenceRepository implements Countable
 {
     /**
      * @var ExternalReference[]

--- a/src/Core/Collections/HashDictionary.php
+++ b/src/Core/Collections/HashDictionary.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Enums\HashAlgorithm;
 use DomainException;
 
@@ -31,7 +32,7 @@ use DomainException;
  *
  * @author jkowalleck
  */
-class HashDictionary implements \Countable
+class HashDictionary implements Countable
 {
     /**
      * @var string[] dictionary of hashes

--- a/src/Core/Collections/LicenseRepository.php
+++ b/src/Core/Collections/LicenseRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
@@ -34,7 +35,7 @@ use CycloneDX\Core\Models\License\LicenseExpression;
  *
  * @author jkowalleck
  */
-class LicenseRepository implements \Countable
+class LicenseRepository implements Countable
 {
     /**
      * @var DisjunctiveLicenseWithId[]|DisjunctiveLicenseWithName[]|LicenseExpression[]

--- a/src/Core/Collections/ToolRepository.php
+++ b/src/Core/Collections/ToolRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Collections;
 
+use Countable;
 use CycloneDX\Core\Models\Tool;
 
 /**
@@ -30,7 +31,7 @@ use CycloneDX\Core\Models\Tool;
  *
  * @author jkowalleck
  */
-class ToolRepository implements \Countable
+class ToolRepository implements Countable
 {
     /**
      * @var Tool[]

--- a/src/Core/Serialization/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/ExternalReferenceRepositoryNormalizer.php
@@ -25,7 +25,9 @@ namespace CycloneDX\Core\Serialization\DOM\Normalizers;
 
 use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Serialization\DOM\_BaseNormalizer;
+use DomainException;
 use DOMElement;
+use UnexpectedValueException;
 
 /**
  * @author jkowalleck
@@ -45,7 +47,7 @@ class ExternalReferenceRepositoryNormalizer extends _BaseNormalizer
         foreach ($repo->getItems() as $externalReference) {
             try {
                 $externalReferences[] = $normalizer->normalize($externalReference);
-            } catch (\DomainException|\UnexpectedValueException) {
+            } catch (DomainException|UnexpectedValueException) {
                 // pass
             }
         }

--- a/src/Core/Validation/Exceptions/FailedLoadingSchemaException.php
+++ b/src/Core/Validation/Exceptions/FailedLoadingSchemaException.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Validation\Exceptions;
 
-class FailedLoadingSchemaException extends \RuntimeException
+use RuntimeException;
+
+class FailedLoadingSchemaException extends RuntimeException
 {
 }

--- a/src/Core/Validation/ValidationError.php
+++ b/src/Core/Validation/ValidationError.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Validation;
 
+use Throwable;
+
 /**
  * @author jkowalleck
  */
@@ -56,7 +58,7 @@ class ValidationError
     /**
      * @internal as this function may be affected by breaking changes without notice
      */
-    public static function fromThrowable(\Throwable $error): static
+    public static function fromThrowable(Throwable $error): static
     {
         $instance = new static($error->getMessage());
         $instance->error = $error;

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -31,6 +31,7 @@ use CycloneDX\Core\Validation\Errors\JsonValidationError;
 use CycloneDX\Core\Validation\Exceptions\FailedLoadingSchemaException;
 use Exception;
 use JsonException;
+use stdClass;
 use Swaggest\JsonSchema;
 
 /**
@@ -71,7 +72,7 @@ class JsonValidator extends BaseValidator
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function validateData(\stdClass $data): ?JsonValidationError
+    public function validateData(stdClass $data): ?JsonValidationError
     {
         $contract = $this->getSchemaContract();
         try {
@@ -106,14 +107,14 @@ class JsonValidator extends BaseValidator
     /**
      * @throws JsonException if loading the JSON failed
      */
-    private function loadDataFromJson(string $json): \stdClass
+    private function loadDataFromJson(string $json): stdClass
     {
         try {
             $data = json_decode($json, false, 512, \JSON_THROW_ON_ERROR);
         } catch (Exception $exception) {
             throw new JsonException('loading failed', 0, $exception);
         }
-        \assert($data instanceof \stdClass);
+        \assert($data instanceof stdClass);
 
         return $data;
     }

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -30,6 +30,7 @@ use CycloneDX\Core\Validation\Errors\XmlValidationError;
 use CycloneDX\Core\Validation\Exceptions\FailedLoadingSchemaException;
 use DOMDocument;
 use DOMException;
+use LibXMLError;
 
 /**
  * @author jkowalleck
@@ -81,7 +82,7 @@ class XmlValidator extends BaseValidator
     /**
      * @throws FailedLoadingSchemaException
      */
-    private function validateDomWithSchema(DOMDocument $doc): ?\LibXMLError
+    private function validateDomWithSchema(DOMDocument $doc): ?LibXMLError
     {
         $schema = $this->getSchemaFile();
 

--- a/src/Core/Validation/_helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
+++ b/src/Core/Validation/_helpers/JsonSchemaRemoteRefProviderForSnapshotResources.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Validation\_helpers;
 
 use CycloneDX\Core\Resources;
+use JsonException;
+use stdClass;
 use Swaggest\JsonSchema;
 
 /**
@@ -38,7 +40,7 @@ class JsonSchemaRemoteRefProviderForSnapshotResources implements JsonSchema\Remo
     /**
      * {@inheritdoc}
      *
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function getSchemaData($url)
     {
@@ -58,7 +60,7 @@ class JsonSchemaRemoteRefProviderForSnapshotResources implements JsonSchema\Remo
         $content = file_get_contents($filePath);
         \assert(\is_string($content));
         $data = json_decode($content, false, 512, \JSON_THROW_ON_ERROR);
-        \assert($data instanceof \stdClass);
+        \assert($data instanceof stdClass);
 
         return $data;
     }

--- a/tests/Core/Collections/HashDictionaryTest.php
+++ b/tests/Core/Collections/HashDictionaryTest.php
@@ -25,6 +25,7 @@ namespace CycloneDX\Tests\Core\Collections;
 
 use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Enums\HashAlgorithm;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -88,7 +89,7 @@ class HashDictionaryTest extends TestCase
     {
         $hashes = new HashDictionary();
 
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessageMatches('/unknown hash algorithm/i');
 
         $hashes->set('unknownAlgorithm', 'foobar');

--- a/tests/Core/Enums/ClassificationTest.php
+++ b/tests/Core/Enums/ClassificationTest.php
@@ -25,7 +25,9 @@ namespace CycloneDX\Tests\Core\Enums;
 
 use CycloneDX\Core\Enums\Classification;
 use CycloneDX\Tests\_data\BomSpecData;
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @covers \CycloneDX\Core\Enums\Classification
@@ -41,15 +43,15 @@ class ClassificationTest extends TestCase
         self::assertSame($expected, Classification::isValidValue($value));
     }
 
-    public function dpKnownValues(): \Generator
+    public function dpKnownValues(): Generator
     {
-        $allValues = (new \ReflectionClass(Classification::class))->getConstants();
+        $allValues = (new ReflectionClass(Classification::class))->getConstants();
         foreach ($allValues as $value) {
             yield $value => [$value, true];
         }
     }
 
-    public function dpUnknownValue(): \Generator
+    public function dpUnknownValue(): Generator
     {
         yield 'invalid' => ['UnknownClassification', false];
     }
@@ -62,7 +64,7 @@ class ClassificationTest extends TestCase
         self::assertTrue(Classification::isValidValue($value));
     }
 
-    public function dpSchemaValues(): \Generator
+    public function dpSchemaValues(): Generator
     {
         $allValues = array_unique(array_merge(
             BomSpecData::getClassificationEnumForVersion('1.0'),

--- a/tests/Core/Enums/ExternalReferenceTypeTest.php
+++ b/tests/Core/Enums/ExternalReferenceTypeTest.php
@@ -25,7 +25,9 @@ namespace CycloneDX\Tests\Core\Enums;
 
 use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Tests\_data\BomSpecData;
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @covers \CycloneDX\Core\Enums\ExternalReferenceType
@@ -41,15 +43,15 @@ class ExternalReferenceTypeTest extends TestCase
         self::assertSame($expected, ExternalReferenceType::isValidValue($value));
     }
 
-    public function dpKnownValues(): \Generator
+    public function dpKnownValues(): Generator
     {
-        $allValues = (new \ReflectionClass(ExternalReferenceType::class))->getConstants();
+        $allValues = (new ReflectionClass(ExternalReferenceType::class))->getConstants();
         foreach ($allValues as $value) {
             yield $value => [$value, true];
         }
     }
 
-    public function dpUnknownValue(): \Generator
+    public function dpUnknownValue(): Generator
     {
         yield 'invalid' => ['UnknownExternalReferenceType', false];
     }
@@ -62,7 +64,7 @@ class ExternalReferenceTypeTest extends TestCase
         self::assertTrue(ExternalReferenceType::isValidValue($value));
     }
 
-    public function dpSchemaValues(): \Generator
+    public function dpSchemaValues(): Generator
     {
         $allValues = array_unique(array_merge(
             BomSpecData::getExternalReferenceTypeForVersion('1.1'),

--- a/tests/Core/Enums/HashAlgorithmTest.php
+++ b/tests/Core/Enums/HashAlgorithmTest.php
@@ -25,7 +25,9 @@ namespace CycloneDX\Tests\Core\Enums;
 
 use CycloneDX\Core\Enums\HashAlgorithm;
 use CycloneDX\Tests\_data\BomSpecData;
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @covers \CycloneDX\Core\Enums\HashAlgorithm
@@ -41,15 +43,15 @@ class HashAlgorithmTest extends TestCase
         self::assertSame($expected, HashAlgorithm::isValidValue($value));
     }
 
-    public function dpKnownValues(): \Generator
+    public function dpKnownValues(): Generator
     {
-        $allValues = (new \ReflectionClass(HashAlgorithm::class))->getConstants();
+        $allValues = (new ReflectionClass(HashAlgorithm::class))->getConstants();
         foreach ($allValues as $value) {
             yield $value => [$value, true];
         }
     }
 
-    public function dpUnknownValue(): \Generator
+    public function dpUnknownValue(): Generator
     {
         yield 'invalid' => ['UnknownAlg', false];
     }
@@ -62,7 +64,7 @@ class HashAlgorithmTest extends TestCase
         self::assertTrue(HashAlgorithm::isValidValue($value));
     }
 
-    public function dpSchemaValues(): \Generator
+    public function dpSchemaValues(): Generator
     {
         $allValues = array_unique(array_merge(
             BomSpecData::getHashAlgEnumForVersion('1.0'),

--- a/tests/Core/Factories/LicenseFactoryTest.php
+++ b/tests/Core/Factories/LicenseFactoryTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
 use DomainException;
+use Exception;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 
@@ -54,7 +55,7 @@ class LicenseFactoryTest extends TestCase
         $exception = null;
         try {
             $factory->getSpdxLicenseValidator();
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             // continue to assertions
         }
 

--- a/tests/Core/Models/BomTest.php
+++ b/tests/Core/Models/BomTest.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Collections\ComponentRepository;
 use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\Metadata;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -89,7 +90,7 @@ class BomTest extends TestCase
     public function testVersionSetterInvalidValue(Bom $bom): void
     {
         $version = 0 - random_int(1, 255);
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $bom->setVersion($version);
     }
 

--- a/tests/Core/Models/ComponentTest.php
+++ b/tests/Core/Models/ComponentTest.php
@@ -30,6 +30,8 @@ use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Enums\Classification;
 use CycloneDX\Core\Models\BomRef;
 use CycloneDX\Core\Models\Component;
+use DomainException;
+use Generator;
 use PackageUrl\PackageUrl;
 use PHPUnit\Framework\TestCase;
 
@@ -110,7 +112,7 @@ class ComponentTest extends TestCase
      */
     public function testSetTypeWithUnknownValue(Component $component): void
     {
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $component->setType('something unknown');
     }
 
@@ -185,7 +187,7 @@ class ComponentTest extends TestCase
         self::assertSame($expected, $component->getDescription());
     }
 
-    public function dpDescriptionSetterGetter(): \Generator
+    public function dpDescriptionSetterGetter(): Generator
     {
         $component = $this->testConstructor();
         yield 'null' => [$component, null, null];
@@ -209,7 +211,7 @@ class ComponentTest extends TestCase
         self::assertSame($expected, $component->getGroup());
     }
 
-    public function dpGroupSetterGetter(): \Generator
+    public function dpGroupSetterGetter(): Generator
     {
         $component = $this->testConstructor();
         yield 'null' => [$component, null, null];

--- a/tests/Core/Models/License/LicenseExpressionTest.php
+++ b/tests/Core/Models/License/LicenseExpressionTest.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Models\License;
 
 use CycloneDX\Core\Models\License\LicenseExpression;
+use DomainException;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,7 +47,7 @@ class LicenseExpressionTest extends TestCase
     {
         $expression = $this->dpInvalidLicenseExpressions()[0];
 
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessageMatches('/invalid expression/i');
 
         new LicenseExpression("$expression");
@@ -67,7 +69,7 @@ class LicenseExpressionTest extends TestCase
         $expression = $this->dpInvalidLicenseExpressions()[0];
         $license = $this->createPartialMock(LicenseExpression::class, []);
 
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessageMatches('/invalid expression/i');
 
         $license->setExpression("$expression");
@@ -82,7 +84,7 @@ class LicenseExpressionTest extends TestCase
         self::assertSame($expected, $isValid);
     }
 
-    public function dpIsValid(): \Generator
+    public function dpIsValid(): Generator
     {
         foreach ($this->dpValidLicenseExpressions() as $license) {
             yield $license => [$license, true];

--- a/tests/Core/ResourcesTest.php
+++ b/tests/Core/ResourcesTest.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core;
 
 use CycloneDX\Core\Resources;
+use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @coversNothing
@@ -47,9 +49,9 @@ class ResourcesTest extends TestCase
         self::assertFileIsReadable($filePath);
     }
 
-    public function dpFiles(): \Generator
+    public function dpFiles(): Generator
     {
-        $constants = (new \ReflectionClass(Resources::class))->getConstants();
+        $constants = (new ReflectionClass(Resources::class))->getConstants();
         foreach ($constants as $name => $value) {
             if (str_starts_with($name, 'FILE')) {
                 yield $name => [$value];

--- a/tests/Core/Serialization/BaseSerializerTest.php
+++ b/tests/Core/Serialization/BaseSerializerTest.php
@@ -31,6 +31,8 @@ use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\BaseSerializer;
 use CycloneDX\Core\Spec\Spec;
+use Exception;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -87,7 +89,7 @@ class BaseSerializerTest extends TestCase
     public function testSerializeForwardsExceptionsFromNormalize(): void
     {
         $bom = $this->createStub(Bom::class);
-        $exception = $this->createMock(\Exception::class);
+        $exception = $this->createMock(Exception::class);
 
         $this->serializer->expects(self::once())
             ->method('normalize')
@@ -150,7 +152,7 @@ class BaseSerializerTest extends TestCase
         self::assertSame('foobar', $actual);
     }
 
-    public function dpBomWithRefs(): \Generator
+    public function dpBomWithRefs(): Generator
     {
         $dependencies = $this->createStub(BomRefRepository::class);
 

--- a/tests/Core/Serialization/DOM/NormalizerFactoryTest.php
+++ b/tests/Core/Serialization/DOM/NormalizerFactoryTest.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\Spec\Spec;
 use DomainException;
+use DOMDocument;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,7 +48,7 @@ class NormalizerFactoryTest extends TestCase
 
         $factory = new NormalizerFactory($spec);
         self::assertSame($spec, $factory->getSpec());
-        self::assertInstanceOf(\DOMDocument::class, $factory->getDocument());
+        self::assertInstanceOf(DOMDocument::class, $factory->getDocument());
 
         return $factory;
     }

--- a/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
@@ -35,6 +35,7 @@ use CycloneDX\Core\Spec\Spec;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
 use DomainException;
 use DOMDocument;
+use Generator;
 use PackageUrl\PackageUrl;
 use PHPUnit\Framework\TestCase;
 
@@ -109,7 +110,7 @@ class ComponentNormalizerTest extends TestCase
         self::assertStringEqualsDomNode($expected, $actual);
     }
 
-    public function dbNormalizeMinimal(): \Generator
+    public function dbNormalizeMinimal(): Generator
     {
         yield 'mandatory ComponentVersion' => [
             '<component type="FakeType"><name>myName</name><version></version></component>',

--- a/tests/Core/Serialization/DOM/Normalizers/ComponentRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ComponentRepositoryNormalizerTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\ComponentNormalizer;
 use CycloneDX\Core\Serialization\DOM\Normalizers\ComponentRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use DOMElement;
 use PHPUnit\Framework\TestCase;
 
@@ -94,7 +95,7 @@ class ComponentRepositoryNormalizerTest extends TestCase
 
         $componentNormalizer->expects(self::exactly(2))->method('normalize')
             ->withConsecutive([$component1], [$component2])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $got = $normalizer->normalize($components);
 

--- a/tests/Core/Serialization/DOM/Normalizers/DependenciesNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/DependenciesNormalizerTest.php
@@ -32,6 +32,9 @@ use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\DependenciesNormalizer;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+use DOMDocument;
+use Exception;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -57,7 +60,7 @@ class DependenciesNormalizerTest extends TestCase
         $this->factory = $this->createConfiguredMock(
             NormalizerFactory::class,
             [
-                'getDocument' => new \DOMDocument(),
+                'getDocument' => new DOMDocument(),
             ]
         );
         $this->normalizer = new DependenciesNormalizer($this->factory);
@@ -82,7 +85,7 @@ class DependenciesNormalizerTest extends TestCase
                 try {
                     self::assertStringEqualsDomNode($expected, $actual);
                     continue 2; // expected was found
-                } catch (\Exception $exception) {
+                } catch (Exception $exception) {
                     // pass
                 }
             }
@@ -99,7 +102,7 @@ class DependenciesNormalizerTest extends TestCase
         );
     }
 
-    public function dpNormalize(): \Generator
+    public function dpNormalize(): Generator
     {
         $dependencies = $this->createStub(BomRefRepository::class);
 

--- a/tests/Core/Serialization/DOM/Normalizers/ExternalReferenceNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ExternalReferenceNormalizerTest.php
@@ -29,6 +29,9 @@ use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\Spec\Spec;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+use DomainException;
+use DOMDocument;
+use Exception;
 
 /**
  * @covers \CycloneDX\Core\Serialization\DOM\Normalizers\ExternalReferenceNormalizer
@@ -42,7 +45,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     {
         $spec = $this->createMock(Spec::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'getSPec' => $spec,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -69,7 +72,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     {
         $spec = $this->createMock(Spec::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'getSpec' => $spec,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -85,7 +88,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
             ->withConsecutive(['someType'], ['other'])
             ->willReturn(false);
 
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessage('ExternalReference has unsupported type: someType');
 
         $normalizer->normalize($extRef);
@@ -95,7 +98,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     {
         $spec = $this->createMock(Spec::class);
         $normalizerFactory = $this->createConfiguredMock(\CycloneDX\Core\Serialization\DOM\NormalizerFactory::class, [
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'getSPec' => $spec,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -124,7 +127,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     {
         $spec = $this->createMock(Spec::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'getSPec' => $spec,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -157,7 +160,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
         $HashDictionaryNormalizer = $this->createMock(Normalizers\HashDictionaryNormalizer::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
             'getSpec' => $spec,
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'makeForHashDictionary' => $HashDictionaryNormalizer,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -188,7 +191,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Exception on assertion error
+     * @throws Exception on assertion error
      */
     public function testNormalizeHashesOmitIfEmpty(): void
     {
@@ -198,7 +201,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
         $HashDictionaryNormalizer = $this->createMock(Normalizers\HashDictionaryNormalizer::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
             'getSpec' => $spec,
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'makeForHashDictionary' => $HashDictionaryNormalizer,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -225,7 +228,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Exception on assertion error
+     * @throws Exception on assertion error
      */
     public function testNormalizeHashesOmitIfNotSupported(): void
     {
@@ -235,7 +238,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
         $HashDictionaryNormalizer = $this->createMock(Normalizers\HashDictionaryNormalizer::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
             'getSpec' => $spec,
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'makeForHashDictionary' => $HashDictionaryNormalizer,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);
@@ -270,7 +273,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
     {
         $spec = $this->createMock(Spec::class);
         $normalizerFactory = $this->createConfiguredMock(NormalizerFactory::class, [
-            'getDocument' => new \DOMDocument(),
+            'getDocument' => new DOMDocument(),
             'getSpec' => $spec,
         ]);
         $normalizer = new Normalizers\ExternalReferenceNormalizer($normalizerFactory);

--- a/tests/Core/Serialization/DOM/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
@@ -28,7 +28,10 @@ use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use DOMElement;
+use Generator;
+use UnexpectedValueException;
 
 /**
  * @covers \CycloneDX\Core\Serialization\DOM\Normalizers\ExternalReferenceRepositoryNormalizer
@@ -114,9 +117,9 @@ class ExternalReferenceRepositoryNormalizerTest extends \PHPUnit\Framework\TestC
         self::assertSame([], $actual);
     }
 
-    public function dpNormalizeSkipsOnThrow(): \Generator
+    public function dpNormalizeSkipsOnThrow(): Generator
     {
-        yield 'DomainException' => [\DomainException::class];
-        yield 'UnexpectedValueException' => [\UnexpectedValueException::class];
+        yield 'DomainException' => [DomainException::class];
+        yield 'UnexpectedValueException' => [UnexpectedValueException::class];
     }
 }

--- a/tests/Core/Serialization/DOM/Normalizers/HashDictionaryNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/HashDictionaryNormalizerTest.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\HashDictionaryNormalizer;
 use CycloneDX\Core\Serialization\DOM\Normalizers\HashNormalizer;
+use DomainException;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\TestCase;
@@ -91,7 +92,7 @@ class HashDictionaryNormalizerTest extends TestCase
         $hashNormalizer->expects(self::exactly(3))
             ->method('normalize')
             ->withConsecutive(['alg1', 'cont1'], ['alg2', 'cont2'], ['alg3', 'cont3'])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $got = $normalizer->normalize($repo);
 

--- a/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
@@ -31,6 +31,7 @@ use CycloneDX\Core\Serialization\DOM\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
 use DOMDocument;
+use Generator;
 
 /**
  * @covers \CycloneDX\Core\Serialization\DOM\Normalizers\LicenseNormalizer
@@ -60,7 +61,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
         self::assertStringEqualsDomNode($expectedXML, $actual);
     }
 
-    public function dpNormalize(): \Generator
+    public function dpNormalize(): Generator
     {
         yield 'license expression' => [
             $this->createConfiguredMock(LicenseExpression::class, [

--- a/tests/Core/Serialization/DOM/Normalizers/MetadataNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/MetadataNormalizerTest.php
@@ -32,6 +32,7 @@ use CycloneDX\Core\Serialization\DOM\Normalizers\MetaDataNormalizer;
 use CycloneDX\Core\Serialization\DOM\Normalizers\ToolRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
 use CycloneDX\Tests\_traits\DomNodeAssertionTrait;
+use DomainException;
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
 
@@ -150,7 +151,7 @@ class MetadataNormalizerTest extends TestCase
         $componentFactory->expects(self::once())
             ->method('normalize')
             ->with($metaData->getComponent())
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $actual = $normalizer->normalize($metaData);
 

--- a/tests/Core/Serialization/DOM/Normalizers/ToolNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ToolNormalizerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Serialization\DOM\Normalizers;
 
+use BadMethodCallException;
 use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Models\Tool;
@@ -149,10 +150,10 @@ class ToolNormalizerTest extends TestCase
 
         $HashDictNormalizer->expects(self::never())
             ->method('normalize')
-            ->willThrowException(new \BadMethodCallException());
+            ->willThrowException(new BadMethodCallException());
         $extRefRepoNormalizer->expects(self::never())
             ->method('normalize')
-            ->willThrowException(new \BadMethodCallException());
+            ->willThrowException(new BadMethodCallException());
 
         $actual = $normalizer->normalize($tool);
 

--- a/tests/Core/Serialization/DOM/Normalizers/ToolRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ToolRepositoryNormalizerTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\ToolNormalizer;
 use CycloneDX\Core\Serialization\DOM\Normalizers\ToolRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use DOMElement;
 use PHPUnit\Framework\TestCase;
 
@@ -100,7 +101,7 @@ class ToolRepositoryNormalizerTest extends TestCase
         $toolNormalizer->expects(self::exactly(2))
             ->method('normalize')
             ->withConsecutive([$tool1], [$tool2])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $actual = $normalizer->normalize($tools);
 

--- a/tests/Core/Serialization/JSON/Normalizers/ComponentNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ComponentNormalizerTest.php
@@ -32,6 +32,7 @@ use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers;
 use CycloneDX\Core\Spec\Spec;
 use DomainException;
+use Generator;
 use PackageUrl\PackageUrl;
 use PHPUnit\Framework\TestCase;
 
@@ -99,7 +100,7 @@ class ComponentNormalizerTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dptNormalizeMinimal(): \Generator
+    public function dptNormalizeMinimal(): Generator
     {
         yield 'mandatory Component Version' => [
             [

--- a/tests/Core/Serialization/JSON/Normalizers/ComponentRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ComponentRepositoryNormalizerTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\ComponentNormalizer;
 use CycloneDX\Core\Serialization\JSON\Normalizers\ComponentRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -91,7 +92,7 @@ class ComponentRepositoryNormalizerTest extends TestCase
 
         $componentNormalizer->expects(self::exactly(2))->method('normalize')
             ->withConsecutive([$component1], [$component2])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $got = $normalizer->normalize($components);
 

--- a/tests/Core/Serialization/JSON/Normalizers/DependenciesNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/DependenciesNormalizerTest.php
@@ -31,6 +31,8 @@ use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\DependenciesNormalizer;
+use Exception;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -74,7 +76,7 @@ class DependenciesNormalizerTest extends TestCase
                 try {
                     self::assertEquals($expected, $actual);
                     continue 2; // expected was found
-                } catch (\Exception $exception) {
+                } catch (Exception $exception) {
                     // pass
                 }
             }
@@ -91,7 +93,7 @@ class DependenciesNormalizerTest extends TestCase
         );
     }
 
-    public function dpNormalize(): \Generator
+    public function dpNormalize(): Generator
     {
         $dependencies = $this->createStub(BomRefRepository::class);
 

--- a/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceNormalizerTest.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 
 /**
  * @covers \CycloneDX\Core\Serialization\JSON\Normalizers\ExternalReferenceNormalizer
@@ -113,7 +114,7 @@ class ExternalReferenceNormalizerTest extends \PHPUnit\Framework\TestCase
             ->withConsecutive(['someType'], ['other'])
             ->willReturn(false);
 
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessage('ExternalReference has unsupported type: someType');
 
         $normalizer->normalize($extRef);

--- a/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ExternalReferenceRepositoryNormalizerTest.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 
 /**
  * @covers \CycloneDX\Core\Serialization\JSON\Normalizers\ExternalReferenceRepositoryNormalizer
@@ -100,7 +101,7 @@ class ExternalReferenceRepositoryNormalizerTest extends \PHPUnit\Framework\TestC
 
         $externalReferenceNormalizer->expects(self::exactly(2))->method('normalize')
             ->withConsecutive([$extRef1], [$extRef2])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $actual = $normalizer->normalize($tools);
 

--- a/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use Generator;
 
 /**
  * @covers \CycloneDX\Core\Serialization\JSON\Normalizers\LicenseNormalizer
@@ -50,7 +51,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dpNormalize(): \Generator
+    public function dpNormalize(): Generator
     {
         yield 'license expression' => [
             $this->createConfiguredMock(LicenseExpression::class, [

--- a/tests/Core/Serialization/JSON/Normalizers/MetadataNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/MetadataNormalizerTest.php
@@ -31,6 +31,7 @@ use CycloneDX\Core\Serialization\JSON\Normalizers\ComponentNormalizer;
 use CycloneDX\Core\Serialization\JSON\Normalizers\MetaDataNormalizer;
 use CycloneDX\Core\Serialization\JSON\Normalizers\ToolRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -140,7 +141,7 @@ class MetadataNormalizerTest extends TestCase
         $componentFactory->expects(self::once())
             ->method('normalize')
             ->with($metaData->getComponent())
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $actual = $normalizer->normalize($metaData);
 

--- a/tests/Core/Serialization/JSON/Normalizers/ToolNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ToolNormalizerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Serialization\JSON\Normalizers;
 
+use BadMethodCallException;
 use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Models\Tool;
@@ -131,10 +132,10 @@ class ToolNormalizerTest extends TestCase
 
         $hashDictNormalizer->expects(self::never())
             ->method('normalize')
-            ->willThrowException(new \BadMethodCallException());
+            ->willThrowException(new BadMethodCallException());
         $extRefRepoNormalizer->expects(self::never())
             ->method('normalize')
-            ->willThrowException(new \BadMethodCallException());
+            ->willThrowException(new BadMethodCallException());
 
         $actual = $normalizer->normalize($tool);
 

--- a/tests/Core/Serialization/JSON/Normalizers/ToolRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ToolRepositoryNormalizerTest.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\ToolNormalizer;
 use CycloneDX\Core\Serialization\JSON\Normalizers\ToolRepositoryNormalizer;
 use CycloneDX\Core\Spec\Spec;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -99,7 +100,7 @@ class ToolRepositoryNormalizerTest extends TestCase
 
         $toolNormalizer->expects(self::exactly(2))->method('normalize')
             ->withConsecutive([$tool1], [$tool2])
-            ->willThrowException(new \DomainException());
+            ->willThrowException(new DomainException());
 
         $actual = $normalizer->normalize($tools);
 

--- a/tests/Core/SerializeToJsonTest.php
+++ b/tests/Core/SerializeToJsonTest.php
@@ -28,6 +28,7 @@ use CycloneDX\Core\Serialization\JsonSerializer;
 use CycloneDX\Core\Spec\SpecFactory;
 use CycloneDX\Core\Validation\Validators\JsonStrictValidator;
 use DomainException;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -65,7 +66,7 @@ class SerializeToJsonTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema12(Bom $bom): void
     {
@@ -90,7 +91,7 @@ class SerializeToJsonTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema13(Bom $bom): void
     {
@@ -115,7 +116,7 @@ class SerializeToJsonTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema14(Bom $bom): void
     {

--- a/tests/Core/SerializeToXmlTest.php
+++ b/tests/Core/SerializeToXmlTest.php
@@ -27,6 +27,7 @@ use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Serialization\XmlSerializer;
 use CycloneDX\Core\Spec\SpecFactory;
 use CycloneDX\Core\Validation\Validators\XmlValidator;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,7 +47,7 @@ class SerializeToXmlTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema11(Bom $bom): void
     {
@@ -70,7 +71,7 @@ class SerializeToXmlTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema12(Bom $bom): void
     {
@@ -94,7 +95,7 @@ class SerializeToXmlTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema13(Bom $bom): void
     {
@@ -118,7 +119,7 @@ class SerializeToXmlTest extends TestCase
      *
      * @dataProvider \CycloneDX\Tests\_data\BomModelProvider::allBomTestData
      *
-     * @throws \Exception on validation failure
+     * @throws Exception on validation failure
      */
     public function testSchema14(Bom $bom): void
     {

--- a/tests/Core/Spdx/LicenseValidatorTest.php
+++ b/tests/Core/Spdx/LicenseValidatorTest.php
@@ -26,6 +26,7 @@ namespace CycloneDX\Tests\Core\Spdx;
 use CycloneDX\Core\Spdx\LicenseValidator;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers  \CycloneDX\Core\Spdx\LicenseValidator
@@ -130,7 +131,7 @@ class LicenseValidatorTest extends TestCase
         $license = $this->createPartialMock(LicenseValidator::class, ['getResourcesFile']);
         $license->method('getResourcesFile')->willReturn($tempFilePath);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/malformed licenses file/i');
 
         $license->loadLicenses();
@@ -144,7 +145,7 @@ class LicenseValidatorTest extends TestCase
         $license = $this->createPartialMock(LicenseValidator::class, ['getResourcesFile']);
         $license->method('getResourcesFile')->willReturn($tempFilePath);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/missing licenses file/i');
 
         $license->loadLicenses();

--- a/tests/Core/Spec/SpecInstanceTestCase.php
+++ b/tests/Core/Spec/SpecInstanceTestCase.php
@@ -30,6 +30,7 @@ use CycloneDX\Core\Spec\Spec;
 use CycloneDX\Tests\_data\BomSpecData;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 abstract class SpecInstanceTestCase extends TestCase
 {
@@ -88,7 +89,7 @@ abstract class SpecInstanceTestCase extends TestCase
     {
         yield 'unknown' => [uniqid('Classification', false), false];
         $known = BomSpecData::getClassificationEnumForVersion($this->getSpecVersion());
-        $values = (new \ReflectionClass(Classification::class))->getConstants();
+        $values = (new ReflectionClass(Classification::class))->getConstants();
         foreach ($values as $value) {
             yield $value => [$value, \in_array($value, $known, true)];
         }
@@ -107,7 +108,7 @@ abstract class SpecInstanceTestCase extends TestCase
     {
         yield 'unknown' => [uniqid('HashAlg', false), false];
         $known = BomSpecData::getHashAlgEnumForVersion($this->getSpecVersion());
-        $values = (new \ReflectionClass(HashAlgorithm::class))->getConstants();
+        $values = (new ReflectionClass(HashAlgorithm::class))->getConstants();
         foreach ($values as $value) {
             yield $value => [$value, \in_array($value, $known, true)];
         }
@@ -141,7 +142,7 @@ abstract class SpecInstanceTestCase extends TestCase
     {
         yield 'unknown' => [uniqid('ExternalReferenceType', false), false];
         $known = BomSpecData::getExternalReferenceTypeForVersion($this->getSpecVersion());
-        $values = (new \ReflectionClass(ExternalReferenceType::class))->getConstants();
+        $values = (new ReflectionClass(ExternalReferenceType::class))->getConstants();
         foreach ($values as $value) {
             yield $value => [$value, \in_array($value, $known, true)];
         }

--- a/tests/Core/Validation/Errors/XmlValidationErrorTest.php
+++ b/tests/Core/Validation/Errors/XmlValidationErrorTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Validation\Errors;
 
 use CycloneDX\Core\Validation\Errors\XmlValidationError;
+use LibXMLError;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,7 +35,7 @@ class XmlValidationErrorTest extends TestCase
 {
     public function testFromLibXMLError(): void
     {
-        $libXmlError = new \LibXMLError();
+        $libXmlError = new LibXMLError();
         $libXmlError->message = 'foo bar';
         $libXmlError->level = \LIBXML_ERR_ERROR;
         $libXmlError->code = 1337;

--- a/tests/Core/Validation/ValidationErrorTest.php
+++ b/tests/Core/Validation/ValidationErrorTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Validation;
 
 use CycloneDX\Core\Validation\ValidationError;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,7 +34,7 @@ class ValidationErrorTest extends TestCase
 {
     public function testFromThrowable(): void
     {
-        $throwable = new \Exception('foo bar');
+        $throwable = new Exception('foo bar');
 
         $error = ValidationError::fromThrowable($throwable);
 

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -40,6 +40,7 @@ use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Models\Tool;
 use Generator;
+use ReflectionClass;
 
 /**
  * common DataProvider.
@@ -209,7 +210,7 @@ abstract class BomModelProvider
     public static function bomWithComponentTypeAllKnown(): Generator
     {
         /** @psalm-var list<string> $known */
-        $known = array_values((new \ReflectionClass(Classification::class))->getConstants());
+        $known = array_values((new ReflectionClass(Classification::class))->getConstants());
         yield from self::bomWithComponentTypes(
             ...$known,
             ...BomSpecData::getClassificationEnumForVersion('1.0'),
@@ -464,7 +465,7 @@ abstract class BomModelProvider
     private static function allHashAlgorithms(): array
     {
         /** @psalm-var list<string> $known */
-        $known = array_values((new \ReflectionClass(HashAlgorithm::class))->getConstants());
+        $known = array_values((new ReflectionClass(HashAlgorithm::class))->getConstants());
 
         return array_values(
             array_unique(
@@ -720,7 +721,7 @@ abstract class BomModelProvider
     public static function externalReferencesForAllTypes(): Generator
     {
         /** @psalm-var list<string> $known */
-        $known = array_values((new \ReflectionClass(ExternalReferenceType::class))->getConstants());
+        $known = array_values((new ReflectionClass(ExternalReferenceType::class))->getConstants());
         $all = array_unique(
             array_merge(
                 $known,

--- a/tests/_data/SpdxLicenseValidatorSingleton.php
+++ b/tests/_data/SpdxLicenseValidatorSingleton.php
@@ -24,13 +24,14 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\_data;
 
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
+use RuntimeException;
 
 abstract class SpdxLicenseValidatorSingleton
 {
     private static ?SpdxLicenseValidator $instance = null;
 
     /**
-     * @throws \RuntimeException if loading licenses failed
+     * @throws RuntimeException if loading licenses failed
      */
     public static function getInstance(): SpdxLicenseValidator
     {

--- a/tests/_traits/DomNodeAssertionTrait.php
+++ b/tests/_traits/DomNodeAssertionTrait.php
@@ -25,12 +25,13 @@ namespace CycloneDX\Tests\_traits;
 
 use DOMDocument;
 use DOMNode;
+use Exception;
 use PHPUnit\Framework\Assert;
 
 trait DomNodeAssertionTrait
 {
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     final protected static function assertDomNodeEqualsDomNode(DOMNode $expected, DomNode $actual): void
     {
@@ -43,7 +44,7 @@ trait DomNodeAssertionTrait
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     final protected static function assertDomNodeEqualsString(DomNode $expected, string $actual): void
     {
@@ -55,7 +56,7 @@ trait DomNodeAssertionTrait
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     final protected static function assertStringEqualsDomNode(string $expected, DOMNode $actual): void
     {


### PR DESCRIPTION
QA tool "phpmd" already tests for proper import of all classes.
here is a "php-cs-fixer" rule to have this applied automatically. 