### PR TITLE
rename licenses

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -62,7 +62,9 @@ All notable changes to this project will be documented in this file.
       and changed parameter & return type to non-nullable, was nullable ([#66] via [#131])
   * `Licenses` namespace
     * `AbstractDisjunctiveLicense`
-       * BREAKING: Removed this class (via [#125], [#131])
+       * BREAKING: removed this class (via [#125], [#131])
+    * `DisjunctiveLicenseWithName` class 
+      * BREAKING: renamed class to `NamedLicense` ([#164] via [#168])
   * `MetaData` class
     * BREAKING: renamed class to `Metadata` ([#133] via [#131])  
       Even though PHP is case-insensitive with class names, autoloaders may be case-sensitive. Therefore, this is considered a breaking change.
@@ -165,8 +167,10 @@ All notable changes to this project will be documented in this file.
 [#151]: https://github.com/CycloneDX/cyclonedx-php-library/pull/151
 [#155]: https://github.com/CycloneDX/cyclonedx-php-library/pull/155
 [#163]: https://github.com/CycloneDX/cyclonedx-php-library/issues/163
+[#164]: https://github.com/CycloneDX/cyclonedx-php-library/issues/164
 [#165]: https://github.com/CycloneDX/cyclonedx-php-library/pull/165
 [#166]: https://github.com/CycloneDX/cyclonedx-php-library/pull/166
+[#168]: https://github.com/CycloneDX/cyclonedx-php-library/pull/168
 
 ## 1.6.3 - 2022-09-15
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Code of v1 is in branch "[1.x](https://github.com/CycloneDX/cyclonedx-php-librar
   * `ExternalReference`, `ExternalReferenceRepository`
   * `HashDictionary`
   * `LicenseExpression`, 
-    `DisjunctiveLicenseWithName` aka NamedLicense, `DisjunctiveLicenseWithId` aka SpdxLicense,
+    `NamedLicense`, `DisjunctiveLicenseWithId` aka SpdxLicense,
     `DisjunctiveLicenseRepository`
   * `Metadata`
   * `Tool`, `ToolRepository`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Code of v1 is in branch "[1.x](https://github.com/CycloneDX/cyclonedx-php-librar
   * `ExternalReference`, `ExternalReferenceRepository`
   * `HashDictionary`
   * `LicenseExpression`, 
-    `NamedLicense`, `DisjunctiveLicenseWithId` aka SpdxLicense,
+    `NamedLicense`, `SpdxLicense`,
     `DisjunctiveLicenseRepository`
   * `Metadata`
   * `Tool`, `ToolRepository`

--- a/src/Core/Collections/LicenseRepository.php
+++ b/src/Core/Collections/LicenseRepository.php
@@ -25,12 +25,12 @@ namespace CycloneDX\Core\Collections;
 
 use Countable;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 
 /**
  * Unique collection of {@see \CycloneDX\Core\Models\License\DisjunctiveLicenseWithId},
- * {@see \CycloneDX\Core\Models\License\DisjunctiveLicenseWithName} and
+ * {@see \CycloneDX\Core\Models\License\NamedLicense} and
  * {@see \CycloneDX\Core\Models\License\LicenseExpression}.
  *
  * @author jkowalleck
@@ -38,16 +38,16 @@ use CycloneDX\Core\Models\License\LicenseExpression;
 class LicenseRepository implements Countable
 {
     /**
-     * @var DisjunctiveLicenseWithId[]|DisjunctiveLicenseWithName[]|LicenseExpression[]
+     * @var DisjunctiveLicenseWithId[]|NamedLicense[]|LicenseExpression[]
      *
-     * @psalm-var list<DisjunctiveLicenseWithId|DisjunctiveLicenseWithName|LicenseExpression>
+     * @psalm-var list<DisjunctiveLicenseWithId|NamedLicense|LicenseExpression>
      */
     private array $items = [];
 
     /**
      * Unsupported Licenses are filtered out silently.
      */
-    public function __construct(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName|LicenseExpression ...$items)
+    public function __construct(DisjunctiveLicenseWithId|NamedLicense|LicenseExpression ...$items)
     {
         $this->addItems(...$items);
     }
@@ -58,7 +58,7 @@ class LicenseRepository implements Countable
      *
      * @return $this
      */
-    public function addItems(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName|LicenseExpression ...$items): self
+    public function addItems(DisjunctiveLicenseWithId|NamedLicense|LicenseExpression ...$items): self
     {
         foreach ($items as $item) {
             if (\in_array($item, $this->items, true)) {
@@ -71,9 +71,9 @@ class LicenseRepository implements Countable
     }
 
     /**
-     * @return DisjunctiveLicenseWithId[]|DisjunctiveLicenseWithName[]|LicenseExpression[]
+     * @return DisjunctiveLicenseWithId[]|NamedLicense[]|LicenseExpression[]
      *
-     * @psalm-return list<DisjunctiveLicenseWithId|DisjunctiveLicenseWithName|LicenseExpression>
+     * @psalm-return list<DisjunctiveLicenseWithId|NamedLicense|LicenseExpression>
      */
     public function getItems(): array
     {

--- a/src/Core/Collections/LicenseRepository.php
+++ b/src/Core/Collections/LicenseRepository.php
@@ -24,12 +24,12 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Collections;
 
 use Countable;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 
 /**
- * Unique collection of {@see \CycloneDX\Core\Models\License\DisjunctiveLicenseWithId},
+ * Unique collection of {@see \CycloneDX\Core\Models\License\SpdxLicense},
  * {@see \CycloneDX\Core\Models\License\NamedLicense} and
  * {@see \CycloneDX\Core\Models\License\LicenseExpression}.
  *
@@ -38,16 +38,16 @@ use CycloneDX\Core\Models\License\NamedLicense;
 class LicenseRepository implements Countable
 {
     /**
-     * @var DisjunctiveLicenseWithId[]|NamedLicense[]|LicenseExpression[]
+     * @var SpdxLicense[]|NamedLicense[]|LicenseExpression[]
      *
-     * @psalm-var list<DisjunctiveLicenseWithId|NamedLicense|LicenseExpression>
+     * @psalm-var list<SpdxLicense|NamedLicense|LicenseExpression>
      */
     private array $items = [];
 
     /**
      * Unsupported Licenses are filtered out silently.
      */
-    public function __construct(DisjunctiveLicenseWithId|NamedLicense|LicenseExpression ...$items)
+    public function __construct(SpdxLicense|NamedLicense|LicenseExpression ...$items)
     {
         $this->addItems(...$items);
     }
@@ -58,7 +58,7 @@ class LicenseRepository implements Countable
      *
      * @return $this
      */
-    public function addItems(DisjunctiveLicenseWithId|NamedLicense|LicenseExpression ...$items): self
+    public function addItems(SpdxLicense|NamedLicense|LicenseExpression ...$items): self
     {
         foreach ($items as $item) {
             if (\in_array($item, $this->items, true)) {
@@ -71,9 +71,9 @@ class LicenseRepository implements Countable
     }
 
     /**
-     * @return DisjunctiveLicenseWithId[]|NamedLicense[]|LicenseExpression[]
+     * @return SpdxLicense[]|NamedLicense[]|LicenseExpression[]
      *
-     * @psalm-return list<DisjunctiveLicenseWithId|NamedLicense|LicenseExpression>
+     * @psalm-return list<SpdxLicense|NamedLicense|LicenseExpression>
      */
     public function getItems(): array
     {

--- a/src/Core/Factories/LicenseFactory.php
+++ b/src/Core/Factories/LicenseFactory.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Factories;
 
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
 use DomainException;
 use UnexpectedValueException;
@@ -50,6 +50,9 @@ class LicenseFactory
             ?? throw new UnexpectedValueException('Missing spdxLicenseValidator');
     }
 
+    /**
+     * @psalm-assert SpdxLicenseValidator $this->spdxLicenseValidator
+     */
     public function setSpdxLicenseValidator(SpdxLicenseValidator $spdxLicenseValidator): self
     {
         $this->spdxLicenseValidator = $spdxLicenseValidator;
@@ -57,7 +60,11 @@ class LicenseFactory
         return $this;
     }
 
-    public function makeFromString(string $license): NamedLicense|DisjunctiveLicenseWithId|LicenseExpression
+    /**
+     * @see makeExpression()
+     * @see makeDisjunctive()
+     */
+    public function makeFromString(string $license): NamedLicense|SpdxLicense|LicenseExpression
     {
         try {
             return $this->makeExpression($license);
@@ -74,12 +81,16 @@ class LicenseFactory
         return new LicenseExpression($license);
     }
 
-    public function makeDisjunctive(string $license): DisjunctiveLicenseWithId|NamedLicense
+    /**
+     * @see makeSpdxLicense()
+     * @see makeNamedLicense()
+     */
+    public function makeDisjunctive(string $license): SpdxLicense|NamedLicense
     {
         try {
-            return $this->makeDisjunctiveWithId($license);
+            return $this->makeSpdxLicense($license);
         } catch (UnexpectedValueException|DomainException) {
-            return $this->makeDisjunctiveWithName($license);
+            return $this->makeNamedLicense($license);
         }
     }
 
@@ -89,12 +100,12 @@ class LicenseFactory
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function makeDisjunctiveWithId(string $license): DisjunctiveLicenseWithId
+    public function makeSpdxLicense(string $license): SpdxLicense
     {
-        return DisjunctiveLicenseWithId::makeValidated($license, $this->getSpdxLicenseValidator());
+        return SpdxLicense::makeValidated($license, $this->getSpdxLicenseValidator());
     }
 
-    public function makeDisjunctiveWithName(string $license): NamedLicense
+    public function makeNamedLicense(string $license): NamedLicense
     {
         return new NamedLicense($license);
     }

--- a/src/Core/Factories/LicenseFactory.php
+++ b/src/Core/Factories/LicenseFactory.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Factories;
 
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
 use DomainException;
 use UnexpectedValueException;
@@ -57,7 +57,7 @@ class LicenseFactory
         return $this;
     }
 
-    public function makeFromString(string $license): DisjunctiveLicenseWithName|DisjunctiveLicenseWithId|LicenseExpression
+    public function makeFromString(string $license): NamedLicense|DisjunctiveLicenseWithId|LicenseExpression
     {
         try {
             return $this->makeExpression($license);
@@ -74,7 +74,7 @@ class LicenseFactory
         return new LicenseExpression($license);
     }
 
-    public function makeDisjunctive(string $license): DisjunctiveLicenseWithId|DisjunctiveLicenseWithName
+    public function makeDisjunctive(string $license): DisjunctiveLicenseWithId|NamedLicense
     {
         try {
             return $this->makeDisjunctiveWithId($license);
@@ -94,8 +94,8 @@ class LicenseFactory
         return DisjunctiveLicenseWithId::makeValidated($license, $this->getSpdxLicenseValidator());
     }
 
-    public function makeDisjunctiveWithName(string $license): DisjunctiveLicenseWithName
+    public function makeDisjunctiveWithName(string $license): NamedLicense
     {
-        return new DisjunctiveLicenseWithName($license);
+        return new NamedLicense($license);
     }
 }

--- a/src/Core/Models/License/NamedLicense.php
+++ b/src/Core/Models/License/NamedLicense.php
@@ -28,7 +28,7 @@ namespace CycloneDX\Core\Models\License;
  *
  * @author jkowalleck
  */
-class DisjunctiveLicenseWithName
+class NamedLicense
 {
     use _DisjunctiveLicenseBase;
 

--- a/src/Core/Models/License/SpdxLicense.php
+++ b/src/Core/Models/License/SpdxLicense.php
@@ -33,7 +33,7 @@ use DomainException;
  *
  * @author jkowalleck
  */
-class DisjunctiveLicenseWithId
+class SpdxLicense
 {
     use _DisjunctiveLicenseBase;
 

--- a/src/Core/Serialization/DOM/Normalizers/LicenseNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/LicenseNormalizer.php
@@ -25,9 +25,9 @@ namespace CycloneDX\Core\Serialization\DOM\Normalizers;
 
 use CycloneDX\Core\_helpers\SimpleDomTrait;
 use CycloneDX\Core\_helpers\XmlTrait;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Serialization\DOM\_BaseNormalizer;
 use DOMElement;
 
@@ -39,7 +39,7 @@ class LicenseNormalizer extends _BaseNormalizer
     use SimpleDomTrait;
     use XmlTrait;
 
-    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license): DOMElement
+    public function normalize(LicenseExpression|SpdxLicense|NamedLicense $license): DOMElement
     {
         return $license instanceof LicenseExpression
             ? $this->normalizeExpression($license)
@@ -64,9 +64,9 @@ class LicenseNormalizer extends _BaseNormalizer
     /**
      * @SuppressWarnings(PHPMD.ShortVariable)
      */
-    private function normalizeDisjunctive(DisjunctiveLicenseWithId|NamedLicense $license): DOMElement
+    private function normalizeDisjunctive(SpdxLicense|NamedLicense $license): DOMElement
     {
-        [$id, $name] = $license instanceof DisjunctiveLicenseWithId
+        [$id, $name] = $license instanceof SpdxLicense
             ? [$license->getId(), null]
             : [null, $license->getName()];
 

--- a/src/Core/Serialization/DOM/Normalizers/LicenseNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/LicenseNormalizer.php
@@ -26,8 +26,8 @@ namespace CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\_helpers\SimpleDomTrait;
 use CycloneDX\Core\_helpers\XmlTrait;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\DOM\_BaseNormalizer;
 use DOMElement;
 
@@ -39,7 +39,7 @@ class LicenseNormalizer extends _BaseNormalizer
     use SimpleDomTrait;
     use XmlTrait;
 
-    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): DOMElement
+    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license): DOMElement
     {
         return $license instanceof LicenseExpression
             ? $this->normalizeExpression($license)
@@ -64,7 +64,7 @@ class LicenseNormalizer extends _BaseNormalizer
     /**
      * @SuppressWarnings(PHPMD.ShortVariable)
      */
-    private function normalizeDisjunctive(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): DOMElement
+    private function normalizeDisjunctive(DisjunctiveLicenseWithId|NamedLicense $license): DOMElement
     {
         [$id, $name] = $license instanceof DisjunctiveLicenseWithId
             ? [$license->getId(), null]

--- a/src/Core/Serialization/JSON/Normalizers/LicenseNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/LicenseNormalizer.php
@@ -24,9 +24,9 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\_helpers\NullAssertionTrait;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Serialization\JSON\_BaseNormalizer;
 use Opis\JsonSchema\Formats\IriFormats;
 
@@ -37,7 +37,7 @@ class LicenseNormalizer extends _BaseNormalizer
 {
     use NullAssertionTrait;
 
-    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license): array
+    public function normalize(LicenseExpression|SpdxLicense|NamedLicense $license): array
     {
         return $license instanceof LicenseExpression
             ? $this->normalizeExpression($license)
@@ -56,9 +56,9 @@ class LicenseNormalizer extends _BaseNormalizer
      * @SuppressWarnings(PHPMD.ShortVariable) $id
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function normalizeDisjunctive(DisjunctiveLicenseWithId|NamedLicense $license): array
+    private function normalizeDisjunctive(SpdxLicense|NamedLicense $license): array
     {
-        [$id, $name] = $license instanceof DisjunctiveLicenseWithId
+        [$id, $name] = $license instanceof SpdxLicense
             ? [$license->getId(), null]
             : [null, $license->getName()];
         $url = $license->getUrl();

--- a/src/Core/Serialization/JSON/Normalizers/LicenseNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/LicenseNormalizer.php
@@ -25,8 +25,8 @@ namespace CycloneDX\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\_helpers\NullAssertionTrait;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\JSON\_BaseNormalizer;
 use Opis\JsonSchema\Formats\IriFormats;
 
@@ -37,7 +37,7 @@ class LicenseNormalizer extends _BaseNormalizer
 {
     use NullAssertionTrait;
 
-    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): array
+    public function normalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license): array
     {
         return $license instanceof LicenseExpression
             ? $this->normalizeExpression($license)
@@ -56,7 +56,7 @@ class LicenseNormalizer extends _BaseNormalizer
      * @SuppressWarnings(PHPMD.ShortVariable) $id
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function normalizeDisjunctive(DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license): array
+    private function normalizeDisjunctive(DisjunctiveLicenseWithId|NamedLicense $license): array
     {
         [$id, $name] = $license instanceof DisjunctiveLicenseWithId
             ? [$license->getId(), null]

--- a/tests/Core/Collections/LicenseRepositoryTest.php
+++ b/tests/Core/Collections/LicenseRepositoryTest.php
@@ -25,13 +25,13 @@ namespace CycloneDX\Tests\Core\Collections;
 
 use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
+use CycloneDX\Core\Models\License\NamedLicense;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \CycloneDX\Core\Collections\LicenseRepository
  */
-class DisjunctiveLicenseRepositoryTest extends TestCase
+class LicenseRepositoryTest extends TestCase
 {
     public function testEmptyConstructor(): void
     {
@@ -44,7 +44,7 @@ class DisjunctiveLicenseRepositoryTest extends TestCase
     public function testNonEmptyConstruct(): void
     {
         $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
-        $license2 = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license2 = $this->createStub(NamedLicense::class);
 
         $repo = new LicenseRepository($license1, $license2, $license1, $license2);
 
@@ -56,9 +56,9 @@ class DisjunctiveLicenseRepositoryTest extends TestCase
 
     public function testAddAndGetItems(): void
     {
-        $license1 = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license1 = $this->createStub(NamedLicense::class);
         $license2 = $this->createStub(DisjunctiveLicenseWithId::class);
-        $license3 = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license3 = $this->createStub(NamedLicense::class);
         $repo = new LicenseRepository($license1, $license2);
 
         $actual = $repo->addItems($license2, $license3, $license3);

--- a/tests/Core/Collections/LicenseRepositoryTest.php
+++ b/tests/Core/Collections/LicenseRepositoryTest.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Collections;
 
 use CycloneDX\Core\Collections\LicenseRepository;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -43,7 +43,7 @@ class LicenseRepositoryTest extends TestCase
 
     public function testNonEmptyConstruct(): void
     {
-        $license1 = $this->createStub(DisjunctiveLicenseWithId::class);
+        $license1 = $this->createStub(SpdxLicense::class);
         $license2 = $this->createStub(NamedLicense::class);
 
         $repo = new LicenseRepository($license1, $license2, $license1, $license2);
@@ -57,7 +57,7 @@ class LicenseRepositoryTest extends TestCase
     public function testAddAndGetItems(): void
     {
         $license1 = $this->createStub(NamedLicense::class);
-        $license2 = $this->createStub(DisjunctiveLicenseWithId::class);
+        $license2 = $this->createStub(SpdxLicense::class);
         $license3 = $this->createStub(NamedLicense::class);
         $repo = new LicenseRepository($license1, $license2);
 

--- a/tests/Core/Factories/LicenseFactoryTest.php
+++ b/tests/Core/Factories/LicenseFactoryTest.php
@@ -24,9 +24,9 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Factories;
 
 use CycloneDX\Core\Factories\LicenseFactory;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
 use DomainException;
 use Exception;
@@ -122,13 +122,13 @@ class LicenseFactoryTest extends TestCase
 
     public function testMakeDisjunctiveIsId(): void
     {
-        $factory = $this->createPartialMock(LicenseFactory::class, ['makeDisjunctiveWithId', 'makeDisjunctiveWithName']);
-        $license = $this->createStub(DisjunctiveLicenseWithId::class);
+        $factory = $this->createPartialMock(LicenseFactory::class, ['makeSpdxLicense', 'makeNamedLicense']);
+        $license = $this->createStub(SpdxLicense::class);
 
-        $factory->expects(self::once())->method('makeDisjunctiveWithId')
+        $factory->expects(self::once())->method('makeSpdxLicense')
             ->with('FooBar')
             ->willReturn($license);
-        $factory->expects(self::never())->method('makeDisjunctiveWithName');
+        $factory->expects(self::never())->method('makeNamedLicense');
 
         $got = $factory->makeDisjunctive('FooBar');
 
@@ -137,13 +137,13 @@ class LicenseFactoryTest extends TestCase
 
     public function testMakeDisjunctiveIsName(): void
     {
-        $factory = $this->createPartialMock(LicenseFactory::class, ['makeDisjunctiveWithId', 'makeDisjunctiveWithName']);
+        $factory = $this->createPartialMock(LicenseFactory::class, ['makeSpdxLicense', 'makeNamedLicense']);
         $license = $this->createStub(NamedLicense::class);
 
-        $factory->expects(self::once())->method('makeDisjunctiveWithId')
+        $factory->expects(self::once())->method('makeSpdxLicense')
             ->with('FooBar')
             ->willThrowException(new DomainException());
-        $factory->expects(self::once())->method('makeDisjunctiveWithName')
+        $factory->expects(self::once())->method('makeNamedLicense')
             ->with('FooBar')
             ->willReturn($license);
 
@@ -153,9 +153,9 @@ class LicenseFactoryTest extends TestCase
     }
 
     /**
-     * @uses \CycloneDX\Core\Models\License\DisjunctiveLicenseWithId
+     * @uses \CycloneDX\Core\Models\License\SpdxLicense
      */
-    public function testMakeDisjunctiveWithId(): void
+    public function testMakeSpdxLicense(): void
     {
         $spdxLicenseValidator = $this->createMock(SpdxLicenseValidator::class);
         $spdxLicenseValidator->method('getLicenses')
@@ -168,7 +168,7 @@ class LicenseFactoryTest extends TestCase
             ->willReturn('FooBar');
         $factory = new LicenseFactory($spdxLicenseValidator);
 
-        $got = $factory->makeDisjunctiveWithId('foobar');
+        $got = $factory->makeSpdxLicense('foobar');
 
         self::assertSame('FooBar', $got->getId());
         self::assertNull($got->getUrl());
@@ -177,11 +177,11 @@ class LicenseFactoryTest extends TestCase
     /**
      *  @uses \CycloneDX\Core\Models\License\NamedLicense
      */
-    public function testMakeDisjunctiveWithName(): void
+    public function testMakeNamedLicense(): void
     {
         $factory = new LicenseFactory();
 
-        $got = $factory->makeDisjunctiveWithName('foo and friends (c) 2342');
+        $got = $factory->makeNamedLicense('foo and friends (c) 2342');
 
         self::assertSame('foo and friends (c) 2342', $got->getName());
         self::assertNull($got->getUrl());

--- a/tests/Core/Factories/LicenseFactoryTest.php
+++ b/tests/Core/Factories/LicenseFactoryTest.php
@@ -25,8 +25,8 @@ namespace CycloneDX\Tests\Core\Factories;
 
 use CycloneDX\Core\Factories\LicenseFactory;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Spdx\LicenseValidator as SpdxLicenseValidator;
 use DomainException;
 use Exception;
@@ -93,7 +93,7 @@ class LicenseFactoryTest extends TestCase
     public function testMakeFromStringIsDisjunctive(): void
     {
         $factory = $this->createPartialMock(LicenseFactory::class, ['makeExpression', 'makeDisjunctive']);
-        $license = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license = $this->createStub(NamedLicense::class);
 
         $factory->expects(self::once())->method('makeExpression')
             ->with('FooBar')
@@ -138,7 +138,7 @@ class LicenseFactoryTest extends TestCase
     public function testMakeDisjunctiveIsName(): void
     {
         $factory = $this->createPartialMock(LicenseFactory::class, ['makeDisjunctiveWithId', 'makeDisjunctiveWithName']);
-        $license = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license = $this->createStub(NamedLicense::class);
 
         $factory->expects(self::once())->method('makeDisjunctiveWithId')
             ->with('FooBar')
@@ -147,9 +147,9 @@ class LicenseFactoryTest extends TestCase
             ->with('FooBar')
             ->willReturn($license);
 
-        $got = $factory->makeDisjunctive('FooBar');
+        $actual = $factory->makeDisjunctive('FooBar');
 
-        self::assertSame($license, $got);
+        self::assertSame($license, $actual);
     }
 
     /**
@@ -175,7 +175,7 @@ class LicenseFactoryTest extends TestCase
     }
 
     /**
-     *  @uses \CycloneDX\Core\Models\License\DisjunctiveLicenseWithName
+     *  @uses \CycloneDX\Core\Models\License\NamedLicense
      */
     public function testMakeDisjunctiveWithName(): void
     {

--- a/tests/Core/Models/License/NamedLicenseTest.php
+++ b/tests/Core/Models/License/NamedLicenseTest.php
@@ -23,17 +23,17 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Models\License;
 
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
+use CycloneDX\Core\Models\License\NamedLicense;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \CycloneDX\Core\Models\License\DisjunctiveLicenseWithName
+ * @covers \CycloneDX\Core\Models\License\NamedLicense
  */
-class DisjunctiveLicenseWithNameTest extends TestCase
+class NamedLicenseTest extends TestCase
 {
-    public function testConstruct(): DisjunctiveLicenseWithName
+    public function testConstruct(): NamedLicense
     {
-        $license = new DisjunctiveLicenseWithName('foo');
+        $license = new NamedLicense('foo');
         self::assertSame('foo', $license->getName());
         self::assertNull($license->getUrl());
 
@@ -43,7 +43,7 @@ class DisjunctiveLicenseWithNameTest extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testSetName(DisjunctiveLicenseWithName $license): void
+    public function testSetName(NamedLicense $license): void
     {
         $license->setName('bar');
         self::assertSame('bar', $license->getName());
@@ -52,7 +52,7 @@ class DisjunctiveLicenseWithNameTest extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testSetAndGetUrl(DisjunctiveLicenseWithName $license): DisjunctiveLicenseWithName
+    public function testSetAndGetUrl(NamedLicense $license): NamedLicense
     {
         $url = uniqid('url', true);
         $license->setUrl($url);
@@ -64,7 +64,7 @@ class DisjunctiveLicenseWithNameTest extends TestCase
     /**
      * @depends testSetAndGetUrl
      */
-    public function testSetUrlNull(DisjunctiveLicenseWithName $license): void
+    public function testSetUrlNull(NamedLicense $license): void
     {
         $license->setUrl(null);
         self::assertNull($license->getUrl());

--- a/tests/Core/Models/License/SpdxLicenseTest.php
+++ b/tests/Core/Models/License/SpdxLicenseTest.php
@@ -23,23 +23,23 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Models\License;
 
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Spdx\LicenseValidator;
 use DomainException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \CycloneDX\Core\Models\License\DisjunctiveLicenseWithId
+ * @covers \CycloneDX\Core\Models\License\SpdxLicense
  */
-class DisjunctiveLicenseWithIdTest extends TestCase
+class SpdxLicenseTest extends TestCase
 {
-    public function testConstruct(): DisjunctiveLicenseWithId
+    public function testConstruct(): SpdxLicense
     {
         $spdxLicenseValidator = $this->createMock(LicenseValidator::class);
         $spdxLicenseValidator->method('validate')->with('foo')->willReturn(true);
         $spdxLicenseValidator->method('getLicense')->with('foo')->willReturn('bar');
 
-        $license = DisjunctiveLicenseWithId::makeValidated('foo', $spdxLicenseValidator);
+        $license = SpdxLicense::makeValidated('foo', $spdxLicenseValidator);
 
         self::assertSame('bar', $license->getId());
         self::assertNull($license->getUrl());
@@ -56,13 +56,13 @@ class DisjunctiveLicenseWithIdTest extends TestCase
         $this->expectException(DomainException::class);
         $this->expectExceptionMessageMatches('/invalid SPDX license/i');
 
-        DisjunctiveLicenseWithId::makeValidated('foo', $spdxLicenseValidator);
+        SpdxLicense::makeValidated('foo', $spdxLicenseValidator);
     }
 
     /**
      * @depends testConstruct
      */
-    public function testSetAndGetUrl(DisjunctiveLicenseWithId $license): DisjunctiveLicenseWithId
+    public function testSetAndGetUrl(SpdxLicense $license): SpdxLicense
     {
         $url = uniqid('url', true);
         $license->setUrl($url);
@@ -74,7 +74,7 @@ class DisjunctiveLicenseWithIdTest extends TestCase
     /**
      * @depends testSetAndGetUrl
      */
-    public function testSetUrlNull(DisjunctiveLicenseWithId $license): void
+    public function testSetUrlNull(SpdxLicense $license): void
     {
         $license->setUrl(null);
         self::assertNull($license->getUrl());

--- a/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
@@ -29,7 +29,7 @@ use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Collections\PropertyRepository;
 use CycloneDX\Core\Models\BomRef;
 use CycloneDX\Core\Models\Component;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers;
 use CycloneDX\Core\Serialization\DOM\Normalizers\PropertyRepositoryNormalizer;
@@ -138,7 +138,7 @@ class ComponentNormalizerTest extends TestCase
                 'getType' => 'FakeType',
                 'getGroup' => 'myGroup',
                 'getDescription' => 'my description',
-                'getLicenses' => $this->createConfiguredMock(LicenseRepository::class, ['count' => 1, 'getItems' => [$this->createMock(DisjunctiveLicenseWithName::class)]]),
+                'getLicenses' => $this->createConfiguredMock(LicenseRepository::class, ['count' => 1, 'getItems' => [$this->createMock(NamedLicense::class)]]),
                 'getHashes' => $this->createConfiguredMock(HashDictionary::class, ['count' => 1]),
                 'getPackageUrl' => $this->createConfiguredMock(
                     PackageUrl::class,

--- a/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialization\DOM\Normalizers;
 
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
@@ -44,7 +44,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpNormalize
      */
-    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license, string $expectedXML): void
+    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license, string $expectedXML): void
     {
         $spec = $this->createMock(Spec::class);
         $factory = $this->createConfiguredMock(
@@ -80,7 +80,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
             '</license>',
         ];
         yield 'named license' => [
-            $this->createConfiguredMock(DisjunctiveLicenseWithName::class, [
+            $this->createConfiguredMock(NamedLicense::class, [
                 'getName' => 'copyright by the crew',
                 'getUrl' => 'https://foo.bar',
             ]),

--- a/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/LicenseNormalizerTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Serialization\DOM\Normalizers;
 
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
@@ -44,7 +44,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpNormalize
      */
-    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license, string $expectedXML): void
+    public function testNormalize(LicenseExpression|SpdxLicense|NamedLicense $license, string $expectedXML): void
     {
         $spec = $this->createMock(Spec::class);
         $factory = $this->createConfiguredMock(
@@ -70,7 +70,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
             '<expression>MIT OR Apache-2.0</expression>',
         ];
         yield 'SPDX license' => [
-            $this->createConfiguredMock(DisjunctiveLicenseWithId::class, [
+            $this->createConfiguredMock(SpdxLicense::class, [
                 'getId' => 'MIT',
                 'getUrl' => 'https://foo.bar',
             ]),

--- a/tests/Core/Serialization/DOM/Normalizers/LicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/LicenseRepositoryNormalizerTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialization\DOM\Normalizers;
 
 use CycloneDX\Core\Collections\LicenseRepository;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\DOM\NormalizerFactory;
 use CycloneDX\Core\Serialization\DOM\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Serialization\DOM\Normalizers\LicenseRepositoryNormalizer;
@@ -66,7 +66,7 @@ class LicenseRepositoryNormalizerTest extends TestCase
             'makeForLicense' => $licenseNormalizer,
         ]);
         $normalizer = new LicenseRepositoryNormalizer($factory);
-        $license = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license = $this->createStub(NamedLicense::class);
         $licenses = $this->createConfiguredMock(LicenseRepository::class, [
             'count' => 1,
             'getItems' => [$license],

--- a/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
@@ -40,7 +40,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpNormalize
      */
-    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|DisjunctiveLicenseWithName $license, array $expected): void
+    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license, array $expected): void
     {
         $spec = $this->createMock(Spec::class);
         $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
@@ -72,7 +72,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         yield 'named license' => [
-            $this->createConfiguredMock(DisjunctiveLicenseWithName::class, [
+            $this->createConfiguredMock(NamedLicense::class, [
                 'getName' => 'copyright by the crew',
                 'getUrl' => 'https://foo.bar',
             ]),

--- a/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/LicenseNormalizerTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Serialization\JSON\Normalizers;
 
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Spec\Spec;
@@ -40,7 +40,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider dpNormalize
      */
-    public function testNormalize(LicenseExpression|DisjunctiveLicenseWithId|NamedLicense $license, array $expected): void
+    public function testNormalize(LicenseExpression|SpdxLicense|NamedLicense $license, array $expected): void
     {
         $spec = $this->createMock(Spec::class);
         $factory = $this->createConfiguredMock(NormalizerFactory::class, ['getSpec' => $spec]);
@@ -60,7 +60,7 @@ class LicenseNormalizerTest extends \PHPUnit\Framework\TestCase
             ['expression' => 'MIT OR Apache-2.0'],
         ];
         yield 'SPDX license' => [
-            $this->createConfiguredMock(DisjunctiveLicenseWithId::class, [
+            $this->createConfiguredMock(SpdxLicense::class, [
                 'getId' => 'MIT',
                 'getUrl' => 'https://foo.bar',
             ]),

--- a/tests/Core/Serialization/JSON/Normalizers/LicenseRepositoryNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/LicenseRepositoryNormalizerTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Tests\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\Collections\LicenseRepository;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers\LicenseNormalizer;
 use CycloneDX\Core\Serialization\JSON\Normalizers\LicenseRepositoryNormalizer;
@@ -62,7 +62,7 @@ class LicenseRepositoryNormalizerTest extends TestCase
             'makeForLicense' => $licenseNormalizer,
         ]);
         $normalizer = new LicenseRepositoryNormalizer($factory);
-        $license = $this->createStub(DisjunctiveLicenseWithName::class);
+        $license = $this->createStub(NamedLicense::class);
         $licenses = $this->createConfiguredMock(LicenseRepository::class, [
             'count' => 1,
             'getItems' => [$license],

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -36,8 +36,8 @@ use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\ExternalReference;
 use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithName;
 use CycloneDX\Core\Models\License\LicenseExpression;
+use CycloneDX\Core\Models\License\NamedLicense;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Models\Property;
 use CycloneDX\Core\Models\Tool;
@@ -411,7 +411,7 @@ abstract class BomModelProvider
                     (new Component(Classification::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
-                                new DisjunctiveLicenseWithName($license)
+                                new NamedLicense($license)
                             )
                         )
                 )
@@ -457,7 +457,7 @@ abstract class BomModelProvider
                     (new Component(Classification::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
-                                (new DisjunctiveLicenseWithName('some text'))
+                                (new NamedLicense('some text'))
                                     ->setUrl('https://example.com/license'),
                             )
                         )

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -35,9 +35,9 @@ use CycloneDX\Core\Enums\HashAlgorithm;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\ExternalReference;
-use CycloneDX\Core\Models\License\DisjunctiveLicenseWithId;
 use CycloneDX\Core\Models\License\LicenseExpression;
 use CycloneDX\Core\Models\License\NamedLicense;
+use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Models\Property;
 use CycloneDX\Core\Models\Tool;
@@ -382,7 +382,7 @@ abstract class BomModelProvider
                     (new Component(Classification::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
-                                DisjunctiveLicenseWithId::makeValidated(
+                                SpdxLicense::makeValidated(
                                     $license,
                                     SpdxLicenseValidatorSingleton::getInstance()
                                 )


### PR DESCRIPTION
fixes #164

* [x]  `DisjunctiveLicenseWithName` -> `NamedLicense`
* [x] `DisjunctiveLicenseWithId` -> `SpdxLicense`
* [x] `makeDisjunctiveWithName` -> `makeNamedLicense`
* [x]  `makeDisjunctiveWithId`  -> `makeSpdxLicense`