### PR TITLE
rename `Classification` -> `ComponentType`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,9 +32,12 @@ All notable changes to this project will be documented in this file.
   * BREAKING: every occurrence of `{M,m}etaData` with a capital "D" was renamed to `{M,m}etadata` with a small "d". ([#133] via [#131], [#149])
     This affected class names, method names, variable names, property names, file names, documentation - everything.
 * `\CycloneDX\Core\Collections` namespace
-  * Added new class `PropertyRepository`. (via [#165])
+  * Added new class `PropertyRepository` (via [#165])
 * `\CycloneDX\Core\Enum` namespace
-  * Added class constant `ExternalReferenceType::RELEASE_NOTES` to reflect CycloneDX v1.4 ([#57] via [#65])
+  * `Classification` class
+    * BREAKING: renamed class to `ComponentType` (via [#170])
+  * `ExternalReferenceType` class
+    * Added class constant `::RELEASE_NOTES` to reflect CycloneDX v1.4 ([#57] via [#65])
 * `CycloneDX\Core\Factories` namespace
   * `LicenseFactory` class
     * Breaking: removed method `makeDisjunctiveFromExpression()` ([#163] vial [#166])
@@ -89,7 +92,7 @@ All notable changes to this project will be documented in this file.
     * BREAKING: renamed the class to `\CycloneDX\Core\Collections\LicenseRepository` (via [#131])
     * BREAKING: added the capability to also aggregate instances of class `Models\LicenseExpression`. (via [#131])
       Therefore, various getters and setters and the constructor changed their signatures,
-      was usage of `Models\License\AbstractDisjunctiveLicense` only.
+      was usage of `\CycloneDX\Core\Models\License\AbstractDisjunctiveLicense` only.
   * `HashRepository` class
     * BREAKING: renamed to `\CycloneDX\Core\Collections\HashDictionary` ([#133] via [#131])
     * BREAKING: renamed all methods and changed all method signatures to match the overall streamlined scheme ([#133] via [#131])
@@ -175,6 +178,7 @@ All notable changes to this project will be documented in this file.
 [#165]: https://github.com/CycloneDX/cyclonedx-php-library/pull/165
 [#166]: https://github.com/CycloneDX/cyclonedx-php-library/pull/166
 [#168]: https://github.com/CycloneDX/cyclonedx-php-library/pull/168
+[#170]: https://github.com/CycloneDX/cyclonedx-php-library/pull/170
 
 ## 1.6.3 - 2022-09-15
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Code of v1 is in branch "[1.x](https://github.com/CycloneDX/cyclonedx-php-librar
 ## Capabilities
 
 * Enums for the following use cases:
-  * `Classification` aka ComponentType
+  * `ComponentType`
   * `ExternalReferenceType`
   * `HashAlgorithm`
 * Data models for the following use cases:
@@ -84,7 +84,7 @@ See extended [examples].
 $bom = new \CycloneDX\Core\Models\Bom();
 $bom->getComponents()->addItems(
     new \CycloneDX\Core\Models\Component(
-        \CycloneDX\Core\Enums\Classification::LIBRARY,
+        \CycloneDX\Core\Enums\ComponentType::LIBRARY,
         'myComponent'
     )
 );

--- a/examples/build_and_serialize.php
+++ b/examples/build_and_serialize.php
@@ -28,12 +28,12 @@ require_once __DIR__.'/../vendor/autoload.php';
 $bom = new \CycloneDX\Core\Models\Bom();
 $bom->getMetadata()->setComponent(
     $rootComponent = new \CycloneDX\Core\Models\Component(
-        \CycloneDX\Core\Enums\Classification::APPLICATION,
+        \CycloneDX\Core\Enums\ComponentType::APPLICATION,
         'myApp'
     )
 );
 $component = new \CycloneDX\Core\Models\Component(
-    \CycloneDX\Core\Enums\Classification::LIBRARY,
+    \CycloneDX\Core\Enums\ComponentType::LIBRARY,
     'myComponent'
 );
 $bom->getComponents()->addItems($component);

--- a/src/Core/Enums/ComponentType.php
+++ b/src/Core/Enums/ComponentType.php
@@ -36,7 +36,7 @@ use ReflectionClass;
  *
  * @author jkowalleck
  */
-abstract class Classification
+abstract class ComponentType
 {
     public const APPLICATION = 'application';
     public const FRAMEWORK = 'framework';

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -28,7 +28,7 @@ use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Collections\PropertyRepository;
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use DomainException;
 use PackageUrl\PackageUrl;
 
@@ -78,7 +78,7 @@ class Component
      * Refer to the {@link https://cyclonedx.org/schema/bom/1.1 bom:classification documentation}
      * for information describing each one.
      *
-     * @psalm-var Classification::*
+     * @psalm-var ComponentType::*
      *
      * @psalm-suppress PropertyNotSetInConstructor
      */
@@ -193,7 +193,7 @@ class Component
     }
 
     /**
-     * @psalm-return Classification::*
+     * @psalm-return ComponentType::*
      */
     public function getType(): string
     {
@@ -201,9 +201,9 @@ class Component
     }
 
     /**
-     * @param string $type A valid {@see \CycloneDX\Core\Enums\Classification}
+     * @param string $type A valid {@see \CycloneDX\Core\Enums\ComponentType}
      *
-     * @psalm-assert Classification::* $type
+     * @psalm-assert ComponentType::* $type
      *
      * @throws DomainException if value is unknown
      *
@@ -213,7 +213,7 @@ class Component
      */
     public function setType(string $type): self
     {
-        $this->type = Classification::isValidValue($type)
+        $this->type = ComponentType::isValidValue($type)
             ? $type
             : throw new DomainException("Invalid type: $type");
 
@@ -343,7 +343,7 @@ class Component
     }
 
     /**
-     * @psalm-assert Classification::* $type
+     * @psalm-assert ComponentType::* $type
      *
      * @throws DomainException if type is unknown
      */

--- a/src/Core/Spec/Spec.php
+++ b/src/Core/Spec/Spec.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Spec;
 
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 
@@ -42,7 +42,7 @@ class Spec
     /**
      * @psalm-param Version::* $sVersion
      * @psalm-param list<Format::*> $lFormats
-     * @psalm-param list<Classification::*> $lComponentTypes
+     * @psalm-param list<ComponentType::*> $lComponentTypes
      * @psalm-param list<HashAlgorithm::*> $lHashAlgorithms
      * @psalm-param list<ExternalReferenceType::*> $lExternalReferenceTypes
      *
@@ -80,9 +80,9 @@ class Spec
         return \in_array($format, $this->lFormats, true);
     }
 
-    public function isSupportedComponentType(string $classification): bool
+    public function isSupportedComponentType(string $componentType): bool
     {
-        return \in_array($classification, $this->lComponentTypes, true);
+        return \in_array($componentType, $this->lComponentTypes, true);
     }
 
     public function isSupportedHashAlgorithm(string $alg): bool

--- a/src/Core/Spec/SpecFactory.php
+++ b/src/Core/Spec/SpecFactory.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Spec;
 
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 use DomainException;
@@ -75,12 +75,12 @@ abstract class SpecFactory
                 Format::XML,
             ],
             [
-                Classification::APPLICATION,
-                Classification::FRAMEWORK,
-                Classification::LIBRARY,
-                Classification::OPERATING_SYSTEMS,
-                Classification::DEVICE,
-                Classification::FILE,
+                ComponentType::APPLICATION,
+                ComponentType::FRAMEWORK,
+                ComponentType::LIBRARY,
+                ComponentType::OPERATING_SYSTEMS,
+                ComponentType::DEVICE,
+                ComponentType::FILE,
             ],
             [
                 HashAlgorithm::MD5,
@@ -133,14 +133,14 @@ abstract class SpecFactory
                 Format::JSON,
             ],
             [
-                Classification::APPLICATION,
-                Classification::FRAMEWORK,
-                Classification::LIBRARY,
-                Classification::OPERATING_SYSTEMS,
-                Classification::DEVICE,
-                Classification::FILE,
-                Classification::CONTAINER,
-                Classification::FIRMWARE,
+                ComponentType::APPLICATION,
+                ComponentType::FRAMEWORK,
+                ComponentType::LIBRARY,
+                ComponentType::OPERATING_SYSTEMS,
+                ComponentType::DEVICE,
+                ComponentType::FILE,
+                ComponentType::CONTAINER,
+                ComponentType::FIRMWARE,
             ],
             [
                 HashAlgorithm::MD5,
@@ -198,14 +198,14 @@ abstract class SpecFactory
                 Format::JSON,
             ],
             [
-                Classification::APPLICATION,
-                Classification::FRAMEWORK,
-                Classification::LIBRARY,
-                Classification::OPERATING_SYSTEMS,
-                Classification::DEVICE,
-                Classification::FILE,
-                Classification::CONTAINER,
-                Classification::FIRMWARE,
+                ComponentType::APPLICATION,
+                ComponentType::FRAMEWORK,
+                ComponentType::LIBRARY,
+                ComponentType::OPERATING_SYSTEMS,
+                ComponentType::DEVICE,
+                ComponentType::FILE,
+                ComponentType::CONTAINER,
+                ComponentType::FIRMWARE,
             ],
             [
                 HashAlgorithm::MD5,
@@ -264,14 +264,14 @@ abstract class SpecFactory
                 Format::JSON,
             ],
             [
-                Classification::APPLICATION,
-                Classification::FRAMEWORK,
-                Classification::LIBRARY,
-                Classification::OPERATING_SYSTEMS,
-                Classification::DEVICE,
-                Classification::FILE,
-                Classification::CONTAINER,
-                Classification::FIRMWARE,
+                ComponentType::APPLICATION,
+                ComponentType::FRAMEWORK,
+                ComponentType::LIBRARY,
+                ComponentType::OPERATING_SYSTEMS,
+                ComponentType::DEVICE,
+                ComponentType::FILE,
+                ComponentType::CONTAINER,
+                ComponentType::FIRMWARE,
             ],
             [
                 HashAlgorithm::MD5,

--- a/tests/Core/Enums/ComponentTypeTest.php
+++ b/tests/Core/Enums/ComponentTypeTest.php
@@ -23,16 +23,16 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Enums;
 
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Tests\_data\BomSpecData;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
- * @covers \CycloneDX\Core\Enums\Classification
+ * @covers \CycloneDX\Core\Enums\ComponentType
  */
-class ClassificationTest extends TestCase
+class ComponentTypeTest extends TestCase
 {
     /**
      * @dataProvider dpKnownValues
@@ -40,12 +40,12 @@ class ClassificationTest extends TestCase
      */
     public function testIsValidValue(string $value, bool $expected): void
     {
-        self::assertSame($expected, Classification::isValidValue($value));
+        self::assertSame($expected, ComponentType::isValidValue($value));
     }
 
     public function dpKnownValues(): Generator
     {
-        $allValues = (new ReflectionClass(Classification::class))->getConstants();
+        $allValues = (new ReflectionClass(ComponentType::class))->getConstants();
         foreach ($allValues as $value) {
             yield $value => [$value, true];
         }
@@ -53,7 +53,7 @@ class ClassificationTest extends TestCase
 
     public function dpUnknownValue(): Generator
     {
-        yield 'invalid' => ['UnknownClassification', false];
+        yield 'invalid' => ['UnknownComponentType', false];
     }
 
     /**
@@ -61,7 +61,7 @@ class ClassificationTest extends TestCase
      */
     public function testIsValidKnowsAllSchemaValues(string $value): void
     {
-        self::assertTrue(Classification::isValidValue($value));
+        self::assertTrue(ComponentType::isValidValue($value));
     }
 
     public function dpSchemaValues(): Generator

--- a/tests/Core/Models/ComponentTest.php
+++ b/tests/Core/Models/ComponentTest.php
@@ -28,7 +28,7 @@ use CycloneDX\Core\Collections\ExternalReferenceRepository;
 use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Collections\PropertyRepository;
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Core\Models\BomRef;
 use CycloneDX\Core\Models\Component;
 use DomainException;
@@ -41,7 +41,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \CycloneDX\Core\Models\Component
  *
- * @uses \CycloneDX\Core\Enums\Classification::isValidValue
+ * @uses \CycloneDX\Core\Enums\ComponentType::isValidValue
  * @uses \CycloneDX\Core\Models\BomRef::__construct
  * @uses \CycloneDX\Core\Collections\LicenseRepository
  * @uses \CycloneDX\Core\Collections\HashDictionary
@@ -52,12 +52,12 @@ use PHPUnit\Framework\TestCase;
 class ComponentTest extends TestCase
 {
     /**
-     * @uses \CycloneDX\Core\Enums\Classification::isValidValue
+     * @uses \CycloneDX\Core\Enums\ComponentType::isValidValue
      * @uses \CycloneDX\Core\Models\BomRef
      */
     public function testConstructor(): Component
     {
-        $type = Classification::LIBRARY;
+        $type = ComponentType::LIBRARY;
         $name = bin2hex(random_bytes(random_int(23, 255)));
 
         $component = new Component($type, $name);
@@ -99,11 +99,11 @@ class ComponentTest extends TestCase
     /**
      * @depends testConstructor
      *
-     * @uses \CycloneDX\Core\Enums\Classification::isValidValue()
+     * @uses \CycloneDX\Core\Enums\ComponentType::isValidValue()
      */
     public function testTypeSetterGetter(Component $component): void
     {
-        $type = Classification::LIBRARY;
+        $type = ComponentType::LIBRARY;
         $component->setType($type);
         self::assertSame($type, $component->getType());
     }
@@ -111,7 +111,7 @@ class ComponentTest extends TestCase
     /**
      * @depends testConstructor
      *
-     * @uses \CycloneDX\Core\Enums\Classification::isValidValue()
+     * @uses \CycloneDX\Core\Enums\ComponentType::isValidValue()
      */
     public function testSetTypeWithUnknownValue(Component $component): void
     {

--- a/tests/Core/Spec/SpecBaseTestCase.php
+++ b/tests/Core/Spec/SpecBaseTestCase.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace CycloneDX\Tests\Core\Spec;
 
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 use CycloneDX\Core\Spec\Spec;
@@ -87,9 +87,9 @@ abstract class SpecBaseTestCase extends TestCase
 
     final public function dpIsSupportedComponentType(): Generator
     {
-        yield 'unknown' => [uniqid('Classification', false), false];
+        yield 'unknown' => [uniqid('ComponentType', false), false];
         $known = BomSpecData::getClassificationEnumForVersion($this->getSpecVersion());
-        $values = (new ReflectionClass(Classification::class))->getConstants();
+        $values = (new ReflectionClass(ComponentType::class))->getConstants();
         foreach ($values as $value) {
             yield $value => [$value, \in_array($value, $known, true)];
         }

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -29,7 +29,7 @@ use CycloneDX\Core\Collections\HashDictionary;
 use CycloneDX\Core\Collections\LicenseRepository;
 use CycloneDX\Core\Collections\PropertyRepository;
 use CycloneDX\Core\Collections\ToolRepository;
-use CycloneDX\Core\Enums\Classification;
+use CycloneDX\Core\Enums\ComponentType;
 use CycloneDX\Core\Enums\ExternalReferenceType;
 use CycloneDX\Core\Enums\HashAlgorithm;
 use CycloneDX\Core\Models\Bom;
@@ -198,14 +198,14 @@ abstract class BomModelProvider
         yield 'component: plain' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    new Component(Classification::LIBRARY, 'name')
+                    new Component(ComponentType::LIBRARY, 'name')
                 )
             ),
         ];
     }
 
     /**
-     * BOMs with all classification types known.
+     * BOMs with all ComponentTypes known.
      *
      * @return Generator<Bom[]>
      *
@@ -214,7 +214,7 @@ abstract class BomModelProvider
     public static function bomWithComponentTypeAllKnown(): Generator
     {
         /** @psalm-var list<string> $known */
-        $known = array_values((new ReflectionClass(Classification::class))->getConstants());
+        $known = array_values((new ReflectionClass(ComponentType::class))->getConstants());
         yield from self::bomWithComponentTypes(
             ...$known,
             ...BomSpecData::getClassificationEnumForVersion('1.0'),
@@ -239,7 +239,7 @@ abstract class BomModelProvider
         yield 'component with empty ExternalReferences' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'dummy'))
+                    (new Component(ComponentType::LIBRARY, 'dummy'))
                         ->setExternalReferences(new ExternalReferenceRepository())
                 )
             ),
@@ -249,7 +249,7 @@ abstract class BomModelProvider
             yield "component with $label" => [
                 (new Bom())->setComponents(
                     new ComponentRepository(
-                        (new Component(Classification::LIBRARY, 'dummy'))
+                        (new Component(ComponentType::LIBRARY, 'dummy'))
                             ->setExternalReferences(new ExternalReferenceRepository($extRef))
                     )
                 ),
@@ -271,7 +271,7 @@ abstract class BomModelProvider
         yield 'component with some properties' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'dummy'))
+                    (new Component(ComponentType::LIBRARY, 'dummy'))
                         ->setProperties(new PropertyRepository(
                             new Property('somePropertyName', 'somePropertyValue-1'),
                             new Property('somePropertyName', 'somePropertyValue-2'),
@@ -379,7 +379,7 @@ abstract class BomModelProvider
         yield "component license: $license" => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
                                 SpdxLicense::makeValidated(
@@ -408,7 +408,7 @@ abstract class BomModelProvider
         yield 'component license: random' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
                                 new NamedLicense($license)
@@ -431,7 +431,7 @@ abstract class BomModelProvider
         yield 'component license expression' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
                                 new LicenseExpression('(Foo or Bar)')
@@ -454,7 +454,7 @@ abstract class BomModelProvider
         yield 'component license with URL' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setLicenses(
                             new LicenseRepository(
                                 (new NamedLicense('some text'))
@@ -481,7 +481,7 @@ abstract class BomModelProvider
                 (new Bom())->setComponents(
                     new ComponentRepository(
                         (
-                            new Component(Classification::LIBRARY, 'name')
+                            new Component(ComponentType::LIBRARY, 'name')
                         )->setVersion($version),
                     )
                 ),
@@ -598,7 +598,7 @@ abstract class BomModelProvider
             yield "component hash alg: $hashAlgorithm" => [
                 (new Bom())->setComponents(
                     new ComponentRepository(
-                        (new Component(Classification::LIBRARY, 'name'))
+                        (new Component(ComponentType::LIBRARY, 'name'))
                             ->setHashes(
                                 new HashDictionary([$hashAlgorithm => '12345678901234567890123456789012'])
                             )
@@ -622,7 +622,7 @@ abstract class BomModelProvider
         yield 'component description: none' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setDescription(null)
                 )
             ),
@@ -630,7 +630,7 @@ abstract class BomModelProvider
         yield 'component description: empty' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setDescription('')
                 )
             ),
@@ -638,7 +638,7 @@ abstract class BomModelProvider
         yield 'component description: random' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setDescription(bin2hex(random_bytes(32)))
                 )
             ),
@@ -646,7 +646,7 @@ abstract class BomModelProvider
         yield 'component description: spaces' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setDescription("\ta  test   ")
                 )
             ),
@@ -654,7 +654,7 @@ abstract class BomModelProvider
         yield 'component description: XML special chars' => [
             (new Bom())->setComponents(
                 new ComponentRepository(
-                    (new Component(Classification::LIBRARY, 'name'))
+                    (new Component(ComponentType::LIBRARY, 'name'))
                         ->setDescription(
                             'this & that'. // an & that is not an XML entity
                             '<strong>html<strong>'. // things that might cause schema-invalid XML
@@ -733,7 +733,7 @@ abstract class BomModelProvider
             (new Bom())->setMetadata(
                 (new Metadata())->setComponent(
                     new Component(
-                        Classification::APPLICATION,
+                        ComponentType::APPLICATION,
                         'foo'
                     )
                 )


### PR DESCRIPTION
internals of the schema have changed, there are multiple different `Classification`s in the XML/JSON schema, for dedicated purposes.
therefore, let's rename the class to reflect its dedicated use case: define the type of component.