### PR TITLE
chore: migrate `set-output` in GH workflows

### DIFF
--- a/.github/workflows/php-dev.yml
+++ b/.github/workflows/php-dev.yml
@@ -28,15 +28,18 @@ env:
 
 jobs:
   asure-dev-setup:
-    name: DevSetup (${{ matrix.os}}, ${{ matrix.php }}, ${{ matrix.dependencies }})
+    name: DevSetup (${{ matrix.os}}, ${{ matrix.php }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os:
+          - "ubuntu-latest"
+          - "macos-latest"
+          - "windows-latest"
         php:
-          - "8.1" # highest supported
-          - "8.0" # lowest supported
+          - "8.1"   # highest supported
+          - "8.0"   # lowest supported
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -51,15 +54,15 @@ jobs:
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ github.job }}-${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          key: composer-${{ github.job }}-${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            composer-${{ github.job }}-${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependencies }}-
             composer-${{ github.job }}-${{ runner.os }}-${{ matrix.php }}-
             composer-${{ github.job }}-${{ runner.os }}-
       - name: Dev-Setup

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,7 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
+        os:
+          - "ubuntu-latest"
         php:
           - "8.1" # highest supported
           - "8.0" # lowest supported
@@ -61,7 +62,8 @@ jobs:
           coverage: pcov,xdebug
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -133,7 +135,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -189,7 +191,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -227,7 +229,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -263,7 +265,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -301,7 +303,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3
@@ -340,7 +342,7 @@ jobs:
           coverage: none
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         # see https://github.com/actions/cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,11 @@ jobs:
       - name: Checkout
         # see https://github.com/actions/checkout
         uses: actions/checkout@v3
-
       - name: Set the version
         id: set_version
         run: |
           VERSION=`cat semver.txt`
-          echo "##[set-output name=version;]$VERSION"
-
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Create github release and git tag for release
         id: create_release
         # see https://github.com/actions/create-release


### PR DESCRIPTION
caused by https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 