### PR TITLE
`metadata.timestamp` as Zulu time.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -77,7 +77,7 @@ All notable changes to this project will be documented in this file.
       Even though PHP is case-insensitive with class names, autoloaders may be case-sensitive. Therefore, this is considered a breaking change.
     * BREAKING: changed methods `{get,set}Tools()` so that their parameter & return type is non-nullable, was nullable ([#66] via [#131])
     * Added new methods `{get,set}Properties()` (via [#165])
-    * Added new methods `{get,set}Timestamp()` (via [#180])
+    * Added new methods `{get,set}Timestamp()` (via [#180], [#])
   * Added new class `Property`. (via [#165])
   * `Tool` class
     * BREAKING: renamed methods `{get,set}ExternalReferenceRepository()` -> `{get,set}ExternalReferences()` ([#133] via [#131])  

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -77,7 +77,7 @@ All notable changes to this project will be documented in this file.
       Even though PHP is case-insensitive with class names, autoloaders may be case-sensitive. Therefore, this is considered a breaking change.
     * BREAKING: changed methods `{get,set}Tools()` so that their parameter & return type is non-nullable, was nullable ([#66] via [#131])
     * Added new methods `{get,set}Properties()` (via [#165])
-    * Added new methods `{get,set}Timestamp()` (via [#180], [#])
+    * Added new methods `{get,set}Timestamp()` (via [#180], [#181])
   * Added new class `Property`. (via [#165])
   * `Tool` class
     * BREAKING: renamed methods `{get,set}ExternalReferenceRepository()` -> `{get,set}ExternalReferences()` ([#133] via [#131])  
@@ -182,6 +182,7 @@ All notable changes to this project will be documented in this file.
 [#170]: https://github.com/CycloneDX/cyclonedx-php-library/pull/170
 [#174]: https://github.com/CycloneDX/cyclonedx-php-library/pull/174
 [#180]: https://github.com/CycloneDX/cyclonedx-php-library/pull/180
+[#181]: https://github.com/CycloneDX/cyclonedx-php-library/pull/181
 
 ## 1.6.3 - 2022-09-15
 

--- a/src/Core/Models/Metadata.php
+++ b/src/Core/Models/Metadata.php
@@ -25,7 +25,7 @@ namespace CycloneDX\Core\Models;
 
 use CycloneDX\Core\Collections\PropertyRepository;
 use CycloneDX\Core\Collections\ToolRepository;
-use DateTime;
+use DateTimeInterface;
 
 /**
  * @author jkowalleck
@@ -35,7 +35,7 @@ class Metadata
     /**
      * The date and time (timestamp) when the BOM was created.
      */
-    private ?DateTime $timestamp = null;
+    private ?DateTimeInterface $timestamp = null;
 
     /**
      * The tool(s) used in the creation of the BOM.
@@ -58,7 +58,7 @@ class Metadata
      */
     private PropertyRepository $properties;
 
-    public function getTimestamp(): ?DateTime
+    public function getTimestamp(): ?DateTimeInterface
     {
         return $this->timestamp;
     }
@@ -66,7 +66,7 @@ class Metadata
     /**
      * @return $this
      */
-    public function setTimestamp(?DateTime $timestamp): self
+    public function setTimestamp(?DateTimeInterface $timestamp): self
     {
         $this->timestamp = $timestamp;
 

--- a/src/Core/Serialization/JSON/Normalizers/MetadataNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/MetadataNormalizer.php
@@ -29,6 +29,9 @@ use CycloneDX\Core\Collections\ToolRepository;
 use CycloneDX\Core\Models\Component;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\JSON\_BaseNormalizer;
+use DateTime;
+use DateTimeInterface;
+use DateTimeZone;
 
 /**
  * @author jkowalleck
@@ -41,7 +44,7 @@ class MetadataNormalizer extends _BaseNormalizer
     {
         return array_filter(
             [
-                'timestamp' => $metadata->getTimestamp()?->format('c'),
+                'timestamp' => $this->normalizeTimestamp($metadata->getTimestamp()),
                 'tools' => $this->normalizeTools($metadata->getTools()),
                 // authors
                 'component' => $this->normalizeComponent($metadata->getComponent()),
@@ -51,6 +54,17 @@ class MetadataNormalizer extends _BaseNormalizer
             ],
             [$this, 'isNotNull']
         );
+    }
+
+    private function normalizeTimestamp(?DateTimeInterface $timestamp): ?string
+    {
+        if (null === $timestamp) {
+            return null;
+        }
+
+        return DateTime::createFromInterface($timestamp)
+            ->setTimezone(new DateTimeZone('UTC'))
+            ->format('Y-m-d\\TH:i:sp');
     }
 
     private function normalizeTools(ToolRepository $tools): ?array

--- a/tests/Core/Serialization/JSON/Normalizers/MetadataNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/MetadataNormalizerTest.php
@@ -31,6 +31,7 @@ use CycloneDX\Core\Serialization\JSON\NormalizerFactory;
 use CycloneDX\Core\Serialization\JSON\Normalizers;
 use CycloneDX\Core\Spec\Spec;
 use DateTime;
+use DateTimeZone;
 use DomainException;
 use PHPUnit\Framework\TestCase;
 
@@ -54,8 +55,8 @@ class MetadataNormalizerTest extends TestCase
 
     public function testNormalizeTimestamp(): void
     {
-        $fakeDate = 'just-now';
-        $timestamp = $this->createMock(DateTime::class);
+        $timeZone = new DateTimeZone('Pacific/Nauru');
+        $timestamp = new DateTime('2000-01-01 00:00:00', $timeZone);
         $metadata = $this->createConfiguredMock(
             Metadata::class,
             ['getTimestamp' => $timestamp]
@@ -67,15 +68,17 @@ class MetadataNormalizerTest extends TestCase
         );
         $normalizer = new Normalizers\MetadataNormalizer($factory);
 
-        $timestamp->method('format')
-            ->with('c')
-            ->willReturn($fakeDate);
-
         $actual = $normalizer->normalize($metadata);
 
         self::assertSame(
-            ['timestamp' => $fakeDate],
-            $actual
+            ['timestamp' => '1999-12-31T12:00:00Z'],
+            $actual,
+            'not the expected Zulu time'
+        );
+        self::assertSame(
+            '2000-01-01T00:00:00+12:00',
+            $timestamp->format('c'),
+            'timestamp was modified'
         );
     }
 

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -41,7 +41,7 @@ use CycloneDX\Core\Models\License\SpdxLicense;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Models\Property;
 use CycloneDX\Core\Models\Tool;
-use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use Generator;
 use ReflectionClass;
@@ -693,12 +693,12 @@ abstract class BomModelProvider
     {
         yield 'metadata: 1984-12-25T08:15Z' => [
             (new Bom())->setMetadata((new Metadata())->setTimestamp(
-                new DateTime('1984-12-25 08:15:00', new DateTimeZone('utc'))
+                new DateTimeImmutable('1984-12-25 08:15:00', new DateTimeZone('utc'))
             )),
         ];
         yield 'metadata: Timestamp 2010-01-28T15:00:00-09:00' => [
             (new Bom())->setMetadata((new Metadata())->setTimestamp(
-                new DateTime('2010-01-28 15:00:00', new DateTimeZone('-09:00'))
+                new DateTimeImmutable('2010-01-28 15:00:00', new DateTimeZone('-09:00'))
             )),
         ];
     }

--- a/tests/_traits/DomNodeAssertionTrait.php
+++ b/tests/_traits/DomNodeAssertionTrait.php
@@ -58,12 +58,12 @@ trait DomNodeAssertionTrait
     /**
      * @throws Exception
      */
-    final protected static function assertStringEqualsDomNode(string $expected, DOMNode $actual): void
+    final protected static function assertStringEqualsDomNode(string $expected, DOMNode $actual, string $message = ''): void
     {
         $container = new DOMDocument();
 
         $actualNode = $container->appendChild($container->importNode($actual, true));
 
-        Assert::assertSame($expected, $actualNode->C14N());
+        Assert::assertSame($expected, $actualNode->C14N(), $message);
     }
 }


### PR DESCRIPTION
timestamps as Zulu time, so that the original timezone of the document creation is not disclosed.

and data is not modified while normalizing
