### PR TITLE
prepare for `JSON bom.properies`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
   * Enumeration-like classes were converted to native [PHP Enumerations](https://www.php.net/manual/en/language.types.enumerations.php) ([#140] via [#204])
 * Added
   * Support for CycloneDX schema/spec v1.4 ([#57] via [#65], [#118], [#123])
-  * Support for [properties](https://cyclonedx.org/use-cases/#properties--name-value-store) ([#228] via [#165], [#229])
+  * Support for [properties](https://cyclonedx.org/use-cases/#properties--name-value-store) ([#228] via [#165], [#229], [#231])
 * Misc
   * All class properties now enforce the correct types ([#6], [#114] via [#125])  
     This is considered a non-breaking change, because the types were already correctly annotated.  
@@ -210,6 +210,7 @@ All notable changes to this project will be documented in this file.
 [#204]: https://github.com/CycloneDX/cyclonedx-php-library/pull/204
 [#228]: https://github.com/CycloneDX/cyclonedx-php-library/issues/228
 [#229]: https://github.com/CycloneDX/cyclonedx-php-library/pull/229
+[#231]: https://github.com/CycloneDX/cyclonedx-php-library/pull/231
 
 ## 1.6.3 - 2022-09-15
 

--- a/src/Core/Serialization/DOM/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/BomNormalizer.php
@@ -29,6 +29,7 @@ use CycloneDX\Core\Collections\PropertyRepository;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\DOM\_BaseNormalizer;
+use CycloneDX\Core\Spec\Format;
 use DOMElement;
 
 /**
@@ -145,7 +146,7 @@ class BomNormalizer extends _BaseNormalizer
 
     private function normalizeProperties(PropertyRepository $properties): ?DOMElement
     {
-        if (false === $this->getNormalizerFactory()->getSpec()->supportsBomProperties()) {
+        if (false === $this->getNormalizerFactory()->getSpec()->supportsBomProperties(Format::XML)) {
             return null;
         }
 

--- a/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialization\JSON\Normalizers;
 
 use CycloneDX\Core\_helpers\Assert;
+use CycloneDX\Core\Collections\PropertyRepository;
 use CycloneDX\Core\Models\Bom;
 use CycloneDX\Core\Models\Metadata;
 use CycloneDX\Core\Serialization\JSON\_BaseNormalizer;
+use CycloneDX\Core\Spec\Format;
 use CycloneDX\Core\Spec\Version;
 
 /**
@@ -66,7 +68,7 @@ class BomNormalizer extends _BaseNormalizer
                 'components' => $factory->makeForComponentRepository()->normalize($bom->getComponents()),
                 'externalReferences' => $this->normalizeExternalReferences($bom),
                 'dependencies' => $this->normalizeDependencies($bom),
-                // 'properties' => not supported, yet - see https://github.com/CycloneDX/specification/issues/130
+                'properties' => $this->normalizeProperties($bom->getProperties()),
             ],
             Assert::isNotNull(...)
         );
@@ -126,5 +128,16 @@ class BomNormalizer extends _BaseNormalizer
         return empty($data)
             ? null
             : $data;
+    }
+
+    private function normalizeProperties(PropertyRepository $properties): ?array
+    {
+        if (false === $this->getNormalizerFactory()->getSpec()->supportsBomProperties(Format::JSON)) {
+            return null;
+        }
+
+        return 0 === \count($properties)
+            ? null
+            : $this->getNormalizerFactory()->makeForPropertyRepository()->normalize($properties);
     }
 }

--- a/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
@@ -66,9 +66,13 @@ class BomNormalizer extends _BaseNormalizer
                 'version' => $bom->getVersion(),
                 'metadata' => $this->normalizeMetadata($bom->getMetadata()),
                 'components' => $factory->makeForComponentRepository()->normalize($bom->getComponents()),
+                // services
                 'externalReferences' => $this->normalizeExternalReferences($bom),
                 'dependencies' => $this->normalizeDependencies($bom),
+                // compositions
+                // vulnerabilities
                 'properties' => $this->normalizeProperties($bom->getProperties()),
+                // signature
             ],
             Assert::isNotNull(...)
         );

--- a/src/Core/Spec/Spec.php
+++ b/src/Core/Spec/Spec.php
@@ -66,5 +66,5 @@ interface Spec
 
     public function supportsComponentProperties(): bool;
 
-    public function supportsBomProperties(): bool;
+    public function supportsBomProperties(Format $format): bool;
 }

--- a/src/Core/Spec/SpecFactory.php
+++ b/src/Core/Spec/SpecFactory.php
@@ -49,8 +49,6 @@ abstract class SpecFactory
     /**
      * Create the appropriate {@see \CycloneDX\Core\Spec\Spec Specification} based on {@see \CycloneDX\Core\Spec\Version}.
      *
-     * @psalm-assert Version::* $version
-     *
      * @throws DomainException when $version was unsupported
      */
     public static function makeForVersion(Version $version): Spec
@@ -120,7 +118,7 @@ abstract class SpecFactory
             false,
             false,
             false,
-            false,
+            [],
         );
     }
 
@@ -187,7 +185,7 @@ abstract class SpecFactory
             false,
             true,
             false,
-            false,
+            [],
         );
     }
 
@@ -254,7 +252,9 @@ abstract class SpecFactory
             true,
             true,
             true,
-            true,
+            [
+                Format::XML,
+            ],
         );
     }
 
@@ -322,7 +322,9 @@ abstract class SpecFactory
             true,
             true,
             true,
-            true,
+            [
+                Format::XML,
+            ],
         );
     }
 }

--- a/src/Core/Spec/_Spec.php
+++ b/src/Core/Spec/_Spec.php
@@ -46,6 +46,7 @@ class _Spec implements Spec
      * @psalm-param list<ComponentType> $lComponentTypes
      * @psalm-param list<HashAlgorithm> $lHashAlgorithms
      * @psalm-param list<ExternalReferenceType> $lExternalReferenceTypes
+     * @psalm-param list<Format> $lFormatsSupportingBomProperties
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -66,7 +67,7 @@ class _Spec implements Spec
         private readonly bool $bMetadataProperties,
         private readonly bool $bComponentAuthor,
         private readonly bool $bComponentProperties,
-        private readonly bool $bBomProperties,
+        private readonly array $lFormatsSupportingBomProperties,
     ) {
     }
 
@@ -150,8 +151,8 @@ class _Spec implements Spec
         return $this->bComponentProperties;
     }
 
-    public function supportsBomProperties(): bool
+    public function supportsBomProperties(Format $format): bool
     {
-        return $this->bBomProperties;
+        return \in_array($format, $this->lFormatsSupportingBomProperties, true);
     }
 }

--- a/tests/Core/Spec/Spec1dot1Test.php
+++ b/tests/Core/Spec/Spec1dot1Test.php
@@ -92,8 +92,8 @@ class Spec1dot1Test extends SpecBaseTestCase
         return false;
     }
 
-    protected static function shouldSupportBomProperties(): bool
+    protected static function shouldSupportBomProperties(): array
     {
-        return false;
+        return [];
     }
 }

--- a/tests/Core/Spec/Spec1dot2Test.php
+++ b/tests/Core/Spec/Spec1dot2Test.php
@@ -92,8 +92,8 @@ class Spec1dot2Test extends SpecBaseTestCase
         return false;
     }
 
-    protected static function shouldSupportBomProperties(): bool
+    protected static function shouldSupportBomProperties(): array
     {
-        return false;
+        return [];
     }
 }

--- a/tests/Core/Spec/Spec1dot3Test.php
+++ b/tests/Core/Spec/Spec1dot3Test.php
@@ -92,8 +92,8 @@ class Spec1dot3Test extends SpecBaseTestCase
         return true;
     }
 
-    protected static function shouldSupportBomProperties(): bool
+    protected static function shouldSupportBomProperties(): array
     {
-        return true;
+        return [Format::XML];
     }
 }

--- a/tests/Core/Spec/Spec1dot4Test.php
+++ b/tests/Core/Spec/Spec1dot4Test.php
@@ -92,8 +92,8 @@ class Spec1dot4Test extends SpecBaseTestCase
         return true;
     }
 
-    protected static function shouldSupportBomProperties(): bool
+    protected static function shouldSupportBomProperties(): array
     {
-        return true;
+        return [Format::XML];
     }
 }

--- a/tests/Core/Spec/SpecBaseTestCase.php
+++ b/tests/Core/Spec/SpecBaseTestCase.php
@@ -205,11 +205,21 @@ abstract class SpecBaseTestCase extends TestCase
 
     abstract protected static function shouldSupportComponentProperties(): bool;
 
-    final public function testSupportsBomProperties(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('dpSupportsBomProperties')]
+    final public function testSupportsBomProperties(Format $format, bool $shouldSupportBomProperties): void
     {
-        $isSupported = static::getSpec()->supportsBomProperties();
-        self::assertSame(static::shouldSupportBomProperties(), $isSupported);
+        $isSupported = static::getSpec()->supportsBomProperties($format);
+        self::assertSame($shouldSupportBomProperties, $isSupported);
     }
 
-    abstract protected static function shouldSupportBomProperties(): bool;
+    final public static function dpSupportsBomProperties(): Generator
+    {
+        $should = static::shouldSupportBomProperties();
+        foreach (Format::cases() as $format) {
+            yield $format->name => [$format, \in_array($format, $should, true)];
+        }
+    }
+
+    /** @return Format[] */
+    abstract protected static function shouldSupportBomProperties(): array;
 }


### PR DESCRIPTION
caused by #228

in preparation of upcoming fix in schema 1.5
see https://github.com/CycloneDX/specification/pull/170 