### PR TITLE
feat: component copyright

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -76,6 +76,7 @@ All notable changes to this project will be documented in this file.
     * BREAKING: changed property `type` to be of type `\CycloneDX\Core\Enum\ComponentType` ([#140] via [#204])  
       This affects constructor arguments, and affects methods `{get,set}Type()`.
     * Added `{get,set}Author()` ([#184] via [#185])
+    * Added `{get,set}Copyright()` ([#238] via [#239])
     * Added `{get,set}Properties()` ([#228] via [#165])
   * `ExternalReference` class
     * BREAKING: renamed methods `{get,set}HashRepository()` -> `{get,set}Hashes()` ([#133] via [#131])  
@@ -211,6 +212,8 @@ All notable changes to this project will be documented in this file.
 [#228]: https://github.com/CycloneDX/cyclonedx-php-library/issues/228
 [#229]: https://github.com/CycloneDX/cyclonedx-php-library/pull/229
 [#231]: https://github.com/CycloneDX/cyclonedx-php-library/pull/231
+[#238]: https://github.com/CycloneDX/cyclonedx-php-library/issues/238
+[#239]: https://github.com/CycloneDX/cyclonedx-php-library/pull/239
 
 ## 1.6.3 - 2022-09-15
 

--- a/src/Core/Models/Component.php
+++ b/src/Core/Models/Component.php
@@ -110,6 +110,11 @@ class Component
     private LicenseRepository $licenses;
 
     /**
+     * A copyright notice informing users of the underlying claims to copyright ownership in a published work.
+     */
+    private ?string $copyright = null;
+
+    /**
      * Specifies the file hashes of the component.
      */
     private HashDictionary $hashes;
@@ -257,6 +262,20 @@ class Component
     public function setLicenses(LicenseRepository $licenses): static
     {
         $this->licenses = $licenses;
+
+        return $this;
+    }
+
+    public function getCopyright(): ?string
+    {
+        return $this->copyright;
+    }
+
+    public function setCopyright(?string $copyright): static
+    {
+        $this->copyright = '' === $copyright
+            ? null
+            : $copyright;
 
         return $this;
     }

--- a/src/Core/Serialization/DOM/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/ComponentNormalizer.php
@@ -92,7 +92,7 @@ class ComponentNormalizer extends _BaseNormalizer
                 // scope
                 $this->normalizeHashes($component->getHashes()),
                 $this->normalizeLicenses($component->getLicenses()),
-                // copyright
+                SimpleDOM::makeSafeTextElement($document, 'copyright', $component->getCopyright()),
                 // cpe
                 $this->normalizePurl($component->getPackageUrl()),
                 // swid

--- a/src/Core/Serialization/JSON/Normalizers/ComponentNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/ComponentNormalizer.php
@@ -74,6 +74,7 @@ class ComponentNormalizer extends _BaseNormalizer
                 'description' => $component->getDescription(),
                 'author' => $component->getAuthor(),
                 'licenses' => $this->normalizeLicenses($component->getLicenses()),
+                'copyright' => $component->getCopyright(),
                 'hashes' => $this->normalizeHashes($component->getHashes()),
                 'purl' => $this->normalizePurl($component->getPackageUrl()),
                 'externalReferences' => $this->normalizeExternalReferences($component->getExternalReferences()),

--- a/tests/Core/Models/ComponentTest.php
+++ b/tests/Core/Models/ComponentTest.php
@@ -68,6 +68,7 @@ class ComponentTest extends TestCase
         self::assertSame($type, $component->getType());
         self::assertNull($component->getVersion());
         self::assertCount(0, $component->getProperties());
+        self::assertNull($component->getCopyright());
 
         return $component;
     }
@@ -270,4 +271,25 @@ class ComponentTest extends TestCase
     }
 
     // endregion clone
+
+    // region copyright setter&getter
+
+    #[DataProvider('dpCopyrightSetterGetter')]
+    public function testCopyrightSetterGetter(?string $copyright, ?string $expected): void
+    {
+        $component = new Component(ComponentType::CONTAINER, 'foo');
+        $actual = $component->setCopyright($copyright);
+        self::assertSame($component, $actual);
+        self::assertSame($expected, $component->getCopyright());
+    }
+
+    public static function dpCopyrightSetterGetter(): Generator
+    {
+        yield 'null' => [null, null];
+        yield 'empty string' => ['', null];
+        $copyright = bin2hex(random_bytes(32));
+        yield 'non-empty-string' => [$copyright, $copyright];
+    }
+
+    // endregion copyright setter&getter
 }

--- a/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
+++ b/tests/Core/Serialization/DOM/Normalizers/ComponentNormalizerTest.php
@@ -140,6 +140,7 @@ class ComponentNormalizerTest extends TestCase
                 'getDescription' => 'my description',
                 'getAuthor' => 'Jan Kowalleck',
                 'getLicenses' => $this->createConfiguredMock(LicenseRepository::class, ['count' => 1, 'getItems' => [$this->createMock(NamedLicense::class)]]),
+                'getCopyright' => '(c) me and the gang',
                 'getHashes' => $this->createConfiguredMock(HashDictionary::class, ['count' => 1]),
                 'getPackageUrl' => $this->createConfiguredMock(
                     PackageUrl::class,
@@ -191,6 +192,7 @@ class ComponentNormalizerTest extends TestCase
             '<description>my description</description>'.
             '<hashes><FakeHash>dummy</FakeHash></hashes>'.
             '<licenses><FakeLicense>dummy</FakeLicense></licenses>'.
+            '<copyright>(c) me and the gang</copyright>'.
             '<purl>FakePURL</purl>'.
             '</component>',
             $actual

--- a/tests/Core/Serialization/JSON/Normalizers/ComponentNormalizerTest.php
+++ b/tests/Core/Serialization/JSON/Normalizers/ComponentNormalizerTest.php
@@ -139,6 +139,7 @@ class ComponentNormalizerTest extends TestCase
                 'getDescription' => 'my description',
                 'getAuthor' => 'Jan Kowalleck',
                 'getLicenses' => $this->createConfiguredMock(LicenseRepository::class, ['count' => 1]),
+                'getCopyright' => '(c) me and the gang',
                 'getHashes' => $this->createConfiguredMock(HashDictionary::class, ['count' => 1]),
                 'getPackageUrl' => $this->createConfiguredMock(
                     PackageUrl::class,
@@ -184,6 +185,7 @@ class ComponentNormalizerTest extends TestCase
                 'author' => 'Jan Kowalleck',
                 'hashes' => ['FakeHashes'],
                 'licenses' => ['FakeLicenses'],
+                'copyright' => '(c) me and the gang',
                 'purl' => 'FakePURL',
             ],
             $actual

--- a/tests/_data/BomModelProvider.php
+++ b/tests/_data/BomModelProvider.php
@@ -162,7 +162,7 @@ abstract class BomModelProvider
         yield from self::bomWithComponentLicenseName();
         yield from self::bomWithComponentLicenseExpression();
         yield from self::bomWithComponentLicenseUrl();
-
+        yield from self::bomWithComponentCopyright();
         yield from self::bomWithComponentHashAlgorithmsAllKnown();
         yield from self::bomWithComponentWithExternalReferences();
         yield from self::bomWithComponentTypeAllKnown();
@@ -462,6 +462,25 @@ abstract class BomModelProvider
                                     ->setUrl('https://example.com/license'),
                             )
                         )
+                )
+            ),
+        ];
+    }
+
+    /**
+     * @return Generator<Bom[]>
+     *
+     * @psalm-return Generator<string, array{0:Bom}>
+     *
+     * @psalm-suppress MissingThrowsDocblock
+     */
+    public static function bomWithComponentCopyright(): Generator
+    {
+        yield 'component with copyright' => [
+            (new Bom())->setComponents(
+                new ComponentRepository(
+                    (new Component(ComponentType::LIBRARY, 'name'))
+                        ->setCopyright('(c) 2042 - by me and the gang')
                 )
             ),
         ];


### PR DESCRIPTION
caused by #238

models and serialization of `component.copyright`