### PR TITLE
slack interfaces/protocols

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -140,7 +140,8 @@ All notable changes to this project will be documented in this file.
     * BREAKING: renamed namespace to `Serialization` ([#5] via [#146])
   * `SerializerInterface` interface
     * BREAKING: renamed to `Serializer` ([#133] via [#155])
-    * BREAKING: existing method `serialize()` got a new optional parameter `$prettyPrint` (via [#155])
+    * BREAKING: method `serialize()` got a new optional parameter `$prettyPrint` (via [#155])
+    * BREAKING: method `serialize()` may throw `\Throwable`, was `\Exception` (via [#253])
   * `BaseSerializer` abstract class
     * BREAKING: complete redesign (via [#155])
   * `{Json,Xml}Serializer` class
@@ -187,6 +188,8 @@ All notable changes to this project will be documented in this file.
     * BREAKING: removed deprecated method `setSpec()` (via [#144])
   * `ValidatorInterface` interface
     * BREAKING: renamed interface to `Validator` ([#133] via [#143])
+    * Removed specification of constructor `__construct()` (via [#253])
+    * Removed specification of method `getSpec()` (via [#253])
   * `Validators\{Json,Xml}Validator` classes
     * Added support for CycloneDX v1.4 ([#57] via [#65])
   * `Validators\JsonValidator` classes
@@ -241,6 +244,7 @@ All notable changes to this project will be documented in this file.
 [#241]: https://github.com/CycloneDX/cyclonedx-php-library/pull/241
 [#247]: https://github.com/CycloneDX/cyclonedx-php-library/issues/247
 [#249]: https://github.com/CycloneDX/cyclonedx-php-library/pull/249
+[#253]: https://github.com/CycloneDX/cyclonedx-php-library/pull/253
 
 ## 1.6.3 - 2022-09-15
 

--- a/src/Core/Serialization/BaseSerializer.php
+++ b/src/Core/Serialization/BaseSerializer.php
@@ -110,7 +110,7 @@ abstract class BaseSerializer implements Serializer
      * @param TNormalizedBom $normalizedBom a version of the Bom that was normalized for serialization
      *
      * @throws Exception
-     **
+     *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     abstract protected function realSerialize(/* TNormalizedBom */ $normalizedBom, ?bool $prettyPrint): string;

--- a/src/Core/Serialization/BaseSerializer.php
+++ b/src/Core/Serialization/BaseSerializer.php
@@ -110,9 +110,7 @@ abstract class BaseSerializer implements Serializer
      * @param TNormalizedBom $normalizedBom a version of the Bom that was normalized for serialization
      *
      * @throws Exception
-     *
-     * @psalm-return non-empty-string
-     *
+     **
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */
     abstract protected function realSerialize(/* TNormalizedBom */ $normalizedBom, ?bool $prettyPrint): string;

--- a/src/Core/Serialization/Serializer.php
+++ b/src/Core/Serialization/Serializer.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace CycloneDX\Core\Serialization;
 
 use CycloneDX\Core\Models\Bom;
-use Exception;
+use Throwable;
 
 /**
  * @author jkowalleck
@@ -32,14 +32,12 @@ use Exception;
 interface Serializer
 {
     /**
-     * Serialize a {@see \CycloneDX\Core\Models\Bom} to {@see string}.
+     * Serialize a {@see \CycloneDX\Core\Models\Bom} to string.
      *
      * @param Bom  $bom         the BOM to serialize
      * @param bool $prettyPrint whether to beatify the resulting string. A `null` value means no preference.
      *
-     * @throws Exception
-     *
-     * @psalm-return non-empty-string
+     * @throws Throwable
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      */

--- a/src/Core/Serialization/XmlSerializer.php
+++ b/src/Core/Serialization/XmlSerializer.php
@@ -74,10 +74,9 @@ class XmlSerializer extends BaseSerializer
             $document->formatOutput = $prettyPrint;
         }
 
-        // option LIBXML_NOEMPTYTAG might lead to errors in consumers
+        // option LIBXML_NOEMPTYTAG might lead to errors in consumers, do not use it.
         $xml = $document->saveXML();
         \assert(false !== $xml);
-        \assert('' !== $xml);
 
         return $xml;
     }

--- a/src/Core/Validation/Validator.php
+++ b/src/Core/Validation/Validator.php
@@ -23,19 +23,10 @@ declare(strict_types=1);
 
 namespace CycloneDX\Core\Validation;
 
-use CycloneDX\Core\Spec\Spec;
-
 /**
  * @author jkowalleck
  */
 interface Validator
 {
-    public function __construct(Spec $spec);
-
-    public function getSpec(): Spec;
-
-    /**
-     * @psalm-param non-empty-string $string
-     */
     public function validateString(string $string): ?ValidationError;
 }

--- a/src/Core/Validation/Validators/JsonValidator.php
+++ b/src/Core/Validation/Validators/JsonValidator.php
@@ -55,8 +55,6 @@ class JsonValidator extends BaseValidator
     }
 
     /**
-     * @psalm-param non-empty-string $string
-     *
      * @throws FailedLoadingSchemaException if schema file unknown or not readable
      * @throws JsonException                if loading the JSON failed
      */

--- a/src/Core/Validation/Validators/XmlValidator.php
+++ b/src/Core/Validation/Validators/XmlValidator.php
@@ -53,8 +53,6 @@ class XmlValidator extends BaseValidator
     }
 
     /**
-     * @psalm-param non-empty-string $string
-     *
      * @throws FailedLoadingSchemaException if schema file unknown or not readable
      * @throws DOMException                 if loading the DOM failed
      */
@@ -99,8 +97,6 @@ class XmlValidator extends BaseValidator
     }
 
     /**
-     * @psalm-param non-empty-string $xml
-     *
      * @throws DOMException if loading the DOM failed
      */
     private function loadDomFromXml(string $xml): DOMDocument


### PR DESCRIPTION
Some interfaces and protocol were too strict:
specified methods that were not bound to the purpose, or did other unnecessary harnessing.


remove these boundaries.