### PR TITLE
fix: possible JSON schema validation issue regarding "version" property

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * fixed a possible JSON schema validation issue regarding "version" property (via [#352])
+
+[#352]: https://github.com/CycloneDX/cyclonedx-php-library/pull/352
+
 ## 3.0.0 - 2023-08-27
 
 * BREAKING

--- a/res/schema/README.md
+++ b/res/schema/README.md
@@ -1,10 +1,10 @@
 # Resources: Schema files
 
 some schema for offline use as download via [script](../../tools/schema-downloader/download.php).  
-original sources: <https://github.com/CycloneDX/specification/tree/1.5/schema>
+original sources: <https://github.com/CycloneDX/specification/tree/master/schema>
 
 Currently using version
-[c320fc0f0b46873864927d9d5684eea7ba439728](https://github.com/CycloneDX/specification/tree/c320fc0f0b46873864927d9d5684eea7ba439728)
+[fd4d383658196992364e5d62568a48c431ace515](https://github.com/CycloneDX/specification/tree/fd4d383658196992364e5d62568a48c431ace515)
 
 | file | note |
 |------|------|

--- a/res/schema/bom-1.2-strict.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.2-strict.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill-of-Material Specification",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/res/schema/bom-1.2.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.2.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill-of-Material Specification",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "properties": {
     "bomFormat": {

--- a/res/schema/bom-1.3-strict.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.3-strict.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill-of-Material Specification",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/res/schema/bom-1.3.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.3.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill-of-Material Specification",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "properties": {
     "bomFormat": {

--- a/res/schema/bom-1.4.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.4.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/res/schema/bom-1.5.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.5.SNAPSHOT.schema.json
@@ -4,10 +4,10 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/res/schema/bom-1.5.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.5.SNAPSHOT.schema.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  
   "required": [
     "bomFormat",
     "specVersion"

--- a/res/schema/bom-1.5.SNAPSHOT.xsd
+++ b/res/schema/bom-1.5.SNAPSHOT.xsd
@@ -474,7 +474,7 @@ limitations under the License.
                     <xs:documentation>Specifies a description for the component</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1">
+            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1" default="required">
                 <xs:annotation>
                     <xs:documentation>Specifies the scope of the component. If scope is not specified, 'required'
                         scope SHOULD be assumed by the consumer of the BOM.</xs:documentation>

--- a/tools/schema-downloader/download.php
+++ b/tools/schema-downloader/download.php
@@ -32,7 +32,7 @@ declare(strict_types=1);
 
 namespace tools\CycloneDX\SchemaDownloader;
 
-const SOURCE_ROOT = 'https://raw.githubusercontent.com/CycloneDX/specification/1.5/schema/';
+const SOURCE_ROOT = 'https://raw.githubusercontent.com/CycloneDX/specification/master/schema/';
 const TARGET_ROOT = __DIR__.'/../../res/schema/';
 
 abstract class BaseDownloadable

--- a/tools/schema-downloader/download.php
+++ b/tools/schema-downloader/download.php
@@ -46,7 +46,7 @@ abstract class BaseDownloadable
     /** @var string */
     public const TargetPattern = TARGET_ROOT.'...';
 
-    /** @psalm-var array<string, string>  */
+    /** @psalm-var array<string, string> */
     public const ReplaceStr = [];
 
     /** @var list<array{0:string, 1:string}> */
@@ -55,27 +55,45 @@ abstract class BaseDownloadable
 
 abstract class BomXsd extends BaseDownloadable
 {
-    final public const Versions = ['1.5',  '1.4', '1.3', '1.2',  '1.1', '1.0'];
+    final public const Versions = ['1.5', '1.4', '1.3', '1.2', '1.1', '1.0'];
     final public const SourcePattern = SOURCE_ROOT.'bom-%s.xsd';
     final public const TargetPattern = TARGET_ROOT.'bom-%s.SNAPSHOT.xsd';
-    final public const ReplaceStr = [
-        'schemaLocation="http://cyclonedx.org/schema/spdx"' => 'schemaLocation="spdx.SNAPSHOT.xsd"',
-        'schemaLocation="https://cyclonedx.org/schema/spdx"' => 'schemaLocation="spdx.SNAPSHOT.xsd"',
+    final public const ReplaceStr = [];
+    final public const ReplaceReg = [
+        '#schemaLocation="https?://cyclonedx.org/schema/spdx"#' => 'schemaLocation="spdx.SNAPSHOT.xsd"',
     ];
-    final public const ReplaceReg = [];
 }
+
+/* "version" is not required but optional with a default value!
+    this is wrong in schema<1.5 */
+const _bomRequired = '"required": [
+    "bomFormat",
+    "specVersion",
+    "version"
+  ],';
+const _bomRequiredReplace = '
+  "required": [
+    "bomFormat",
+    "specVersion"
+  ],';
 
 abstract class BomJsonLax extends BaseDownloadable
 {
-    final public const Versions = ['1.5', '1.4', '1.3',  '1.2'];
+    final public const Versions = ['1.5', '1.4', '1.3', '1.2'];
     final public const SourcePattern = SOURCE_ROOT.'bom-%s.schema.json';
     final public const TargetPattern = TARGET_ROOT.'bom-%s.SNAPSHOT.schema.json';
     final public const ReplaceStr = [
         'spdx.schema.json' => 'spdx.SNAPSHOT.schema.json',
         'jsf-0.82.schema.json' => 'jsf-0.82.SNAPSHOT.schema.json',
+        _bomRequired => _bomRequiredReplace,
     ];
     final public const ReplaceReg = [
-        ['/("\$id": "(http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json)".*"enum": \[\s+")http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json"/s', '$1$2"'],
+        /* fix "$schema" property to match $id */
+        '/("\$id": "(http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json)".*"enum": \[\s+")http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json"/s' => '$1$2"',
+        /* there was a case where the default value did not match the own pattern ...
+            this is wrong in schema<1.5
+            with current SchemaValidator this is no longer required, as defaults are not applied */
+        // '/\s+"default": "",(?![^}]*?"pattern": "\^\(\.\*\)\$")/gm' => ''
     ];
 }
 
@@ -94,7 +112,7 @@ const OtherDownloadables = [
     SOURCE_ROOT.'jsf-0.82.schema.json' => TARGET_ROOT.'jsf-0.82.SNAPSHOT.schema.json',
 ];
 
-/** @psalm-var class-string<BaseDownloadable>  $class */
+/** @psalm-var class-string<BaseDownloadable> $class */
 foreach ([
              BomXsd::class,
              BomJsonLax::class,
@@ -106,7 +124,7 @@ foreach ([
 
         $content = file_get_contents($source);
         $content = strtr($content, $class::ReplaceStr);
-        foreach ($class::ReplaceReg as [$rp, $rr]) {
+        foreach ($class::ReplaceReg as $rp => $rr) {
             $content = preg_replace($rp, $rr, $content);
         }
 


### PR DESCRIPTION
some schema versions have property "version" required, despite it has a default value.
this was a mistake, fixed in schema v1.5 via https://github.com/CycloneDX/specification/pull/260

this is a compatibility-fix for versions <1.5