### PR TITLE
style: typehint consts

### DIFF
--- a/src/Core/Serialization/BomRefDiscriminator.php
+++ b/src/Core/Serialization/BomRefDiscriminator.php
@@ -30,6 +30,7 @@ use CycloneDX\Core\Models\BomRef;
  */
 class BomRefDiscriminator
 {
+    /** @var string */
     private const PREFIX = 'BomRef.';
 
     /**

--- a/src/Core/Serialization/DOM/NormalizerFactory.php
+++ b/src/Core/Serialization/DOM/NormalizerFactory.php
@@ -36,6 +36,7 @@ use DOMDocument;
  */
 class NormalizerFactory
 {
+    /** @var Format */
     public const FORMAT = Format::XML;
 
     private readonly Spec $spec;

--- a/src/Core/Serialization/DOM/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialization/DOM/Normalizers/BomNormalizer.php
@@ -37,6 +37,7 @@ use DOMElement;
  */
 class BomNormalizer extends _BaseNormalizer
 {
+    /** @var string */
     private const XML_NAMESPACE_PATTERN = 'http://cyclonedx.org/schema/bom/%s';
 
     public function normalize(Bom $bom): DOMElement

--- a/src/Core/Serialization/JSON/NormalizerFactory.php
+++ b/src/Core/Serialization/JSON/NormalizerFactory.php
@@ -35,6 +35,7 @@ use DomainException;
  */
 class NormalizerFactory
 {
+    /** @var Format */
     public const FORMAT = Format::JSON;
 
     private readonly Spec $spec;

--- a/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
+++ b/src/Core/Serialization/JSON/Normalizers/BomNormalizer.php
@@ -36,6 +36,7 @@ use CycloneDX\Core\Spec\Version;
  */
 class BomNormalizer extends _BaseNormalizer
 {
+    /** @var string */
     private const BOM_FORMAT = 'CycloneDX';
 
     /** @psalm-pure  */

--- a/src/Core/Serialization/JsonSerializer.php
+++ b/src/Core/Serialization/JsonSerializer.php
@@ -46,6 +46,8 @@ class JsonSerializer extends BaseSerializer
      * Some JSON flags could break the output, so they are not whitelisted.
      *
      * @see https://www.php.net/manual/en/json.constants.php
+     *
+     * @var int
      */
     private const JsonEncodeFlagsAllowedOptions = 0
         | \JSON_HEX_TAG
@@ -65,6 +67,8 @@ class JsonSerializer extends BaseSerializer
      * These defaults are required to have valid output in the end.
      *
      * @see https://www.php.net/manual/en/json.constants.php
+     *
+     * @var int
      */
     private const JsonEncodeFlagsDefaults = 0
         | \JSON_THROW_ON_ERROR // prevent unexpected data
@@ -77,6 +81,8 @@ class JsonSerializer extends BaseSerializer
      * Bitmask consisting of JSON_*.
      *
      * @see https://www.php.net/manual/en/json.constants.php
+     *
+     * @var int
      */
     private const JsonEncodeFlagsDefaultOptions = 0
         | \JSON_UNESCAPED_SLASHES // urls become shorter


### PR DESCRIPTION
since php83 it is possible to static type class consts.
this is usefull when inheriting classes, and preventing wrong types on override that change the const ... downstream

no need to type consts in `final` classes

since this lib supports php<83, we cannot static type consts.
but we could add type annotations :D 