### PR TITLE
fix: json validation allow arbitrary `$schema`  value

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 <!-- add unreleased items here -->
 
+* Fixed
+  * JsonValidator allow arbitrary `$schema` value ([#435] via [#436])
+
+[#435]: https://github.com/CycloneDX/cyclonedx-php-library/issues/435
+[#436]: https://github.com/CycloneDX/cyclonedx-php-library/pull/436
+
 ## 3.3.0 - 2024-04-26
 
 * Changed

--- a/res/schema/README.md
+++ b/res/schema/README.md
@@ -30,4 +30,4 @@ changes:
 1. `https?://cyclonedx.org/schema/spdx` was replaced with `spdx.SNAPSHOT.xsd`
 2. `spdx.schema.json` was replaced with `spdx.SNAPSHOT.schema.json`
 3. `jsf-0.82.schema.json` was replaced with `jsf-0.82.SNAPSHOT.schema.json`
-4. `properties.$schema.enum` was fixed to match `$id`
+4. `properties.$schema.enum` was removed

--- a/res/schema/bom-1.2-strict.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.2-strict.SNAPSHOT.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.2b.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "$id": "#/properties/bomFormat",

--- a/res/schema/bom-1.3-strict.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.3-strict.SNAPSHOT.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.3a.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "$id": "#/properties/bomFormat",

--- a/res/schema/bom-1.4.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.4.SNAPSHOT.schema.json
@@ -12,10 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.4.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "type": "string",

--- a/res/schema/bom-1.5.SNAPSHOT.schema.json
+++ b/res/schema/bom-1.5.SNAPSHOT.schema.json
@@ -11,10 +11,7 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "http://cyclonedx.org/schema/bom-1.5.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "type": "string",

--- a/tests/Core/Validation/Validators/JsonStrictValidatorTest.php
+++ b/tests/Core/Validation/Validators/JsonStrictValidatorTest.php
@@ -105,6 +105,7 @@ class JsonStrictValidatorTest extends TestCase
         $spec = $this->createConfiguredMock(_SpecProtocol::class, ['getVersion' => Version::v1dot2]);
         $validator = new JsonStrictValidator($spec);
         $data = (object) [
+            '$schema' => 'http://cyclonedx.org/schema/bom-1.2.schema.json',
             'bomFormat' => 'CycloneDX',
             'specVersion' => '1.2',
             'version' => 1,
@@ -132,6 +133,7 @@ class JsonStrictValidatorTest extends TestCase
         $spec = $this->createConfiguredMock(_SpecProtocol::class, ['getVersion' => Version::v1dot2]);
         $validator = new JsonStrictValidator($spec);
         $data = (object) [
+            '$schema' => 'http://cyclonedx.org/schema/bom-1.2.schema.json',
             'bomFormat' => 'CycloneDX',
             'specVersion' => '1.2',
             'version' => 1,

--- a/tests/Core/Validation/Validators/JsonValidatorTest.php
+++ b/tests/Core/Validation/Validators/JsonValidatorTest.php
@@ -104,8 +104,9 @@ class JsonValidatorTest extends TestCase
         $spec = $this->createConfiguredMock(_SpecProtocol::class, ['getVersion' => Version::v1dot2]);
         $validator = new JsonValidator($spec);
         $data = (object) [
+            '$schema' => 'http://cyclonedx.org/schema/bom-1.2.schema.json',
             'bomFormat' => 'CycloneDX',
-            'specVersion' => '1.2',
+            'specVersion' => '1.3',
             'version' => 1,
             'components' => [
                 (object) [
@@ -137,6 +138,7 @@ class JsonValidatorTest extends TestCase
         $spec = $this->createConfiguredMock(_SpecProtocol::class, ['getVersion' => Version::v1dot2]);
         $validator = new JsonValidator($spec);
         $data = (object) [
+            '$schema' => 'http://cyclonedx.org/schema/bom-1.2.schema.json',
             'bomFormat' => 'CycloneDX',
             'specVersion' => '1.2',
             'version' => 1,

--- a/tools/schema-downloader/download.php
+++ b/tools/schema-downloader/download.php
@@ -88,8 +88,11 @@ abstract class BomJsonLax extends BaseDownloadable
         _bomRequired => _bomRequiredReplace,
     ];
     final public const ReplaceReg = [
-        /* fix "$schema" property to match $id */
-        '/("\$id": "(http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json)".*"enum": \[\s+")http:\/\/cyclonedx\.org\/schema\/bom.+?\.schema\.json"/s' => '$1$2"',
+        /* "$schema" is not required but optional.
+           that enum constraint value there is complicated -> remove it.
+           See https://github.com/CycloneDX/specification/issues/402
+           See https://github.com/CycloneDX/specification/pull/403 */
+        '#,?\\s*"enum"\\s*:\\s*\\[\\s+"http://cyclonedx\\.org/schema\/.+?\\.schema\\.json"\\s*\\]#s' => '',
         /* there was a case where the default value did not match the own pattern ...
             this is wrong in schema<1.5
             with current SchemaValidator this is no longer required, as defaults are not applied */


### PR DESCRIPTION
fixes https://github.com/CycloneDX/cyclonedx-php-library/issues/435