### PR TITLE
docs: fix RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,8 +16,8 @@ build:
     - plantuml
   jobs:
     pre_build:
-      - wget https://phpdoc.org/phpDocumentor.phar -O /tmp/phpDocumentor.phar
-      - php /tmp/phpDocumentor.phar run
+      - wget https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.0/phpDocumentor.phar -O /tmp/phpDocumentor.phar
+      - php /tmp/phpDocumentor.phar
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
broken build on master: https://readthedocs.org/projects/cyclonedx-php-library/builds/24689975/

fixed build from this PR/branch: https://readthedocs.org/projects/cyclonedx-php-library/builds/24689978/
fixed build res: https://cyclonedx-php-library.readthedocs.io/en/docs-fix-rtd-build/


reason: phpdocumentor changed it's CLI - the removed the `run` command without notice